### PR TITLE
Allow multi-select for adding files to Design

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -244,8 +244,8 @@ app.whenReady().then(() => {
   ipcMain.handle("get-app-data-path", () => {
     return appDataPath
   })
-  ipcMain.handle("dialog:openFile", (event, args) => {
-    return dialog.showOpenDialog(args);
+  ipcMain.handle("dialog:openFile", (event, options) => {
+    return dialog.showOpenDialog(options);
   });
   ipcMain.handle("dialog:showMessageBoxSync", (event, args) => {
     return dialog.showMessageBoxSync(args);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -245,7 +245,7 @@ app.whenReady().then(() => {
     return appDataPath
   })
   ipcMain.handle("dialog:openFile", (event, args) => {
-    return dialog.showOpenDialog(args[0]);
+    return dialog.showOpenDialog(args);
   });
   ipcMain.handle("dialog:showMessageBoxSync", (event, args) => {
     return dialog.showMessageBoxSync(args);

--- a/src/app/actions/file.ts
+++ b/src/app/actions/file.ts
@@ -9,34 +9,40 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
 
 const nanoid = customAlphabet('1234567890abcdef', 10);
 
-export async function addFile(filePath: string, storagePath: string, designID: string) {
+export async function addFile(filePaths: string[] | string, storagePath: string, designID: string) {
   const appDataDir = path.join(storagePath, 'designs', designID.padStart(5, '0'));
-  const fileName = path.basename(filePath);
-  const fileExtension = path.extname(fileName);
-  const newFileName = `${nanoid(6)}_${fileName}`;
-  const newFilePath = path.join(appDataDir, newFileName);
+
+  // Support both single and multiple files for backward compatibility
+  const files = Array.isArray(filePaths) ? filePaths : [filePaths];
 
   try {
     // Ensure the design directory exists
     await fs.mkdir(appDataDir, { recursive: true });
 
-    // Copy the file to the application data directory
-    await fs.copyFile(filePath, newFilePath);
+    for (const filePath of files) {
+      const fileName = path.basename(filePath);
+      const fileExtension = path.extname(fileName);
+      const newFileName = `${nanoid(6)}_${fileName}`;
+      const newFilePath = path.join(appDataDir, newFileName);
 
-    // Insert metadata into the design_asset table
-    const response = await fetch(`${API_URL}/api/design/${designID}/asset`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        file_path: newFilePath,
-        file_ext: fileExtension.slice(1),  // remove the dot from the extension
-        file_name: fileName,  // original file name
-      }),
-    })
-    if (!response.ok) {
-      throw new Error('Failed to add file metadata');
+      // Copy the file to the application data directory
+      await fs.copyFile(filePath, newFilePath);
+
+      // Insert metadata into the design_asset table
+      const response = await fetch(`${API_URL}/api/design/${designID}/asset`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          file_path: newFilePath,
+          file_ext: fileExtension.slice(1),  // remove the dot from the extension
+          file_name: fileName,  // original file name
+        }),
+      });
+      if (!response.ok) {
+        throw new Error('Failed to add file metadata');
+      }
     }
   } catch (error) {
     log.error('Error adding file:', error);

--- a/src/app/design/[designID]/page.tsx
+++ b/src/app/design/[designID]/page.tsx
@@ -103,17 +103,22 @@ const DesignDetailsPage = () => {
     try {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error
-      const result = await window.electron.dialog.showOpenDialog({ properties: ['openFile'] });
+      const result = await window.electron.dialog.showOpenDialog({ properties: ['openFile', 'multiSelections'] });
       if (result.canceled) {
         log.info("No file selected!");
         return;
       }
 
-      const filePath = result.filePaths[0];
+      const filePaths = result.filePaths;
+      if (!filePaths || filePaths.length === 0) {
+        log.info("No files selected!");
+        return;
+      }
+
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error
       const assetsDir = path.join(await window.electron.getAppDataPath(), "assets");
-      await addFile(filePath, assetsDir, designID);
+      await addFile(filePaths, assetsDir, designID);
 
       const updatedDesign = await fetchDesign(designID.toString());
       setDesign(updatedDesign);


### PR DESCRIPTION
Relates to https://github.com/DrawnToDigital/pubman/issues/53

### Multi-file support:

* `electron/main.ts`: Updated the `dialog:openFile` handler to fix a bug in passing arguments
* `src/app/design/[designID]/page.tsx`: Modified the file dialog to allow multiple selections (`multiSelections`) and updated the logic to handle multiple file paths.