### PR TITLE
All tests should pass

### DIFF
--- a/src/app/api/thingiverse/[thingId]/publish/thingId-publish.test.js
+++ b/src/app/api/thingiverse/[thingId]/publish/thingId-publish.test.js
@@ -29,9 +29,11 @@ describe('POST /api/thingiverse/[thingId]/publish', () => {
   it('should return 404 if design not found in database', async () => {
     // Mock Thingiverse API
     const mockPublishResult = {success: true};
+    const mockGetThingById = jest.fn().mockResolvedValue({is_published: 0});
     const mockPublishThing = jest.fn().mockResolvedValue(mockPublishResult);
 
     ThingiverseAPI.mockImplementation(() => ({
+      getThingById: mockGetThingById,
       publishThing: mockPublishThing
     }));
 
@@ -66,14 +68,16 @@ describe('POST /api/thingiverse/[thingId]/publish', () => {
   it('should publish the thing and update the database', async () => {
     // Mock Thingiverse API
     const mockPublishResult = {success: true};
+    const mockGetThingById = jest.fn().mockResolvedValue({is_published: 0});
     const mockPublishThing = jest.fn().mockResolvedValue(mockPublishResult);
 
     ThingiverseAPI.mockImplementation(() => ({
+      getThingById: mockGetThingById,
       publishThing: mockPublishThing
     }));
 
     // Mock database operations
-    const mockDesignPlatform = {design_id: '42'};
+    const mockDesignPlatform = {id: 36};
     const mockGetDesignPlatform = jest.fn().mockReturnValue(mockDesignPlatform);
 
     const mockUpdateResult = {changes: 1};
@@ -89,7 +93,7 @@ describe('POST /api/thingiverse/[thingId]/publish', () => {
     const mockGetUpdatedRecord = jest.fn().mockReturnValue(mockUpdatedRecord);
 
     const mockPrepare = jest.fn().mockImplementation((query) => {
-      if (query.includes('SELECT design_id')) {
+      if (query.includes('SELECT id')) {
         return {get: mockGetDesignPlatform};
       } else if (query.includes('UPDATE design_platform')) {
         return {run: mockRun};
@@ -122,17 +126,19 @@ describe('POST /api/thingiverse/[thingId]/publish', () => {
     expect(mockPublishThing).toHaveBeenCalledWith('12345');
 
     // Verify database operations
-    expect(mockPrepare).toHaveBeenCalledWith(expect.stringContaining('SELECT design_id'));
+    expect(mockPrepare).toHaveBeenCalledWith(expect.stringContaining('SELECT id'));
     expect(mockPrepare).toHaveBeenCalledWith(expect.stringContaining('UPDATE design_platform'));
-    expect(mockRun).toHaveBeenCalledWith(2, 3, '42');
+    expect(mockRun).toHaveBeenCalledWith(2, 36);
   });
 
   it('should handle API errors', async () => {
     // Mock Thingiverse API to throw an error
     const mockError = new Error('API Error');
+    const mockGetThingById = jest.fn().mockReturnValue({is_published: 0});
     const mockPublishThing = jest.fn().mockRejectedValue(mockError);
 
     ThingiverseAPI.mockImplementation(() => ({
+      getThingById: mockGetThingById,
       publishThing: mockPublishThing
     }));
 

--- a/src/app/api/thingiverse/things/things-POST.test.js
+++ b/src/app/api/thingiverse/things/things-POST.test.js
@@ -50,7 +50,7 @@ describe('POST /api/thingiverse/things', () => {
       main_name: 'Test Design',
       description: 'Test Description',
       license_key: 'cc-by',
-      categories: [{category: 'Art'}],
+      thingiverse_category: 'Art',
       tags: [{tag: 'test1'}, {tag: 'test2'}],
       assets: [
         // Use a simpler path format that matches the local:// prefix exactly


### PR DESCRIPTION
All tests in `npm test` should `pass`

```
npm test

> pubman@2025.6.2 test
> jest

 PASS  src/app/api/thingiverse/[thingId]/publish/thingId-publish.test.js
 PASS  src/app/api/thingiverse/things/things-POST.test.js
 PASS  src/app/api/thingiverse/[thingId]/files/thingId-files.test.js
 PASS  src/app/api/thingiverse/[thingId]/thingId-PATCH.test.js
 PASS  src/app/api/thingiverse/tv-GET.test.js

Test Suites: 5 passed, 5 total
Tests:       19 passed, 19 total
Snapshots:   0 total
Time:        0.196 s, estimated 1 s
Ran all test suites.
```

### Updates to `POST /api/thingiverse/[thingId]/publish` tests:

* Added a mock implementation for the `getThingById` method in `ThingiverseAPI` to simulate fetching the publication status of a Thingiverse item.
* Updated mocked database queries to use the `id` field instead of `design_id`, reflecting changes in the query since the test was written.

### Updates to `POST /api/thingiverse/things` tests:

* Adjusted test data to replace `categories` with `thingiverse_category`, aligning with the updated API structure.