### PR TITLE
MakerWorld login support for TFA verification

### DIFF
--- a/src/app/api/makerworld/auth/login-tfa/route.js
+++ b/src/app/api/makerworld/auth/login-tfa/route.js
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { MakerWorldAPI } from "../../makerworld-lib";
+
+export async function POST(req) {
+  let resp = null;
+  try {
+    const { tfaCode, tfaKey } = await req.json();
+    if (!tfaCode || !tfaKey) {
+      return NextResponse.json({ error: "Missing tfaCode or tfaKey" }, { status: 400 });
+    }
+    const api = new MakerWorldAPI();
+    resp = await api.loginVerifyTfaCode(tfaCode, tfaKey);
+    return NextResponse.json(resp);
+  } catch (err) {
+    console.error("TFA verification error:", err, "Response:", resp);
+    return NextResponse.json({ error: err.message || "TFA verification failed" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
Closes #70

This pull request introduces two-factor authentication (TFA) support for the MakerWorld login flow. Key changes include adding a new API endpoint for TFA verification, updating the login page to handle TFA steps, and extending the `MakerWorldAPI` class with methods for TFA code validation.

### TFA Support Integration:

#### Backend changes:
* Added a new `POST` endpoint in `src/app/api/makerworld/auth/login-tfa/route.js` to verify TFA codes using the `MakerWorldAPI`. The endpoint handles missing parameters and errors gracefully.
* Extended the `MakerWorldAPI` class in `src/app/api/makerworld/makerworld-lib.js` with a `loginVerifyTfaCode` method to validate TFA codes and extract tokens from response headers.

#### Frontend changes:
* Updated `src/app/api/makerworld/auth/page.js` to include state variables (`tfaKey` and `tfaCode`) and a new login step for TFA. [[1]](diffhunk://#diff-d3e909cc162ae8d2b0b93f27c56ed16c95642811235d21cd39237c1edebce018R11-R12) [[2]](diffhunk://#diff-d3e909cc162ae8d2b0b93f27c56ed16c95642811235d21cd39237c1edebce018R33-R35)
* Added a form for TFA verification, including input for the TFA code and error handling.
* Implemented the `handleTfa` function to send TFA codes and keys to the new backend endpoint and handle responses.

### Schema and Response Handling Improvements:
* Added `LoginVerifyTfaKeyRequestSchema` to validate TFA request objects.
* Improved response parsing in `MakerWorldAPI` methods by explicitly parsing JSON responses and handling validation issues. [[1]](diffhunk://#diff-9a76df44e2041305db57943ef304d7a08c6671758d24984f121befc71c90f7edL494-R507) [[2]](diffhunk://#diff-9a76df44e2041305db57943ef304d7a08c6671758d24984f121befc71c90f7edL517-R561)

These changes collectively enable secure TFA verification for MakerWorld users, enhancing the authentication process.