### PR TITLE
Links in description of design should open externally

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -238,6 +238,9 @@ app.whenReady().then(() => {
   });
 
   ipcMain.on("ping", () => log.info("pong"));
+  ipcMain.handle("shell:openExternal", (event, url) => {
+    return shell.openExternal(url);
+  });
   ipcMain.handle("get-db-path", () => {
     return dbPath;
   })

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -12,6 +12,9 @@ contextBridge.exposeInMainWorld("electron", {
     showMessageBoxSync: (options: Electron.MessageBoxSyncOptions) =>
       ipcRenderer.invoke("dialog:showMessageBoxSync", options),
   },
+  shell: {
+    openExternal: (url: string) => ipcRenderer.invoke("shell:openExternal", url),
+  },
   getDBPath: () => ipcRenderer.invoke("get-db-path"),
   getAppDataPath: () => ipcRenderer.invoke("get-app-data-path"),
 });

--- a/src/app/design/[designID]/page.tsx
+++ b/src/app/design/[designID]/page.tsx
@@ -369,6 +369,20 @@ const DesignDetailsPage = () => {
             <div
               className="prose text-gray-700 whitespace-pre-wrap"
               dangerouslySetInnerHTML={{ __html: design.description }}
+              onClick={e => {
+                const target = e.target as HTMLElement;
+                if (target.tagName === 'A') {
+                  e.preventDefault();
+                  // @ts-expect-error electron is defined in preload script
+                  window.electron?.shell?.openExternal?.(target.getAttribute('href'));
+                }
+              }}
+              onMouseOver={e => {
+                const target = e.target as HTMLElement;
+                if (target.tagName === 'A') {
+                  target.setAttribute('title', target.getAttribute('href') || '');
+                }
+              }}
             />
           </div>
 


### PR DESCRIPTION
Relates to #69

Clicking on a link from the design description would open the url in the PubMan window, but we would expect it to open a new default browser window. 