### PR TITLE
Fixes link to view new draft on Printables

### DIFF
--- a/src/app/api/printables/model/route.js
+++ b/src/app/api/printables/model/route.js
@@ -209,7 +209,7 @@ export async function POST(request) {
 
     return NextResponse.json({
       message: designId ? `Design updated ${hasFileErrors ? 'with errors ': ''}on Printables` : `Design published ${hasFileErrors ? 'with errors ': ''}to Printables as draft`,
-      designId: designResponse.id,
+      printablesId: designResponse.id,
       printablesUrl: `https://www.printables.com/model/${designResponse.id}`,
       hasFileErrors: hasFileErrors,
       fileResults: fileResults,

--- a/src/app/components/design/platform-publishing.tsx
+++ b/src/app/components/design/platform-publishing.tsx
@@ -169,6 +169,7 @@ export function PlatformPublishing(props: PlatformPublishingInternalProps) {
                 {platformStatus.url && (
                   <Link
                     href={platformStatus.url}
+                    title={platformStatus.url}
                     target="_blank"
                     className="text-blue-500 hover:underline block mt-1"
                   >
@@ -208,6 +209,7 @@ export function PlatformPublishing(props: PlatformPublishingInternalProps) {
                 {platformStatus.url && (
                   <Link
                     href={platformStatus.url}
+                    title={platformStatus.url}
                     target="_blank"
                     className="text-blue-500 hover:underline block mt-1"
                   >


### PR DESCRIPTION
Relates to #69 

When publishing a new Draft design to Printables, the "View on Printables" link was broken. The printables-publishing component was expecting a `printablesId` field to be populated.