### PR TITLE
Warn before unsaved changes are lost in editMode

### DIFF
--- a/src/app/components/design/design-form.tsx
+++ b/src/app/components/design/design-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useForm, FormProvider } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
@@ -47,6 +47,22 @@ const DesignForm = () => {
       makerworld_category: null,
     },
   });
+
+  useEffect(() => {
+    // @ts-expect-error global var
+    window.__pubman_isEditing = true;
+    // Warn on browser/tab close or reload if editing
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => {
+      // @ts-expect-error global var
+      window.__pubman_isEditing = false;
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, []);
 
   const onSubmit = async (data: DesignCreateSchema) => {
     setErrorMessage(null); // Clear previous errors

--- a/src/app/components/design/platform-publishing.tsx
+++ b/src/app/components/design/platform-publishing.tsx
@@ -14,6 +14,7 @@ export interface PlatformPublishingProps {
   setErrorMessage: (message: string | null) => void;
   setSuccessMessage: (message: string | null) => void;
   onDesignUpdated: (design: DesignSchema) => void;
+  editMode?: boolean;
 }
 
 // Internal props, including all platform-specific and implementation props
@@ -49,6 +50,7 @@ export function PlatformPublishing(props: PlatformPublishingInternalProps) {
     publishDraft,
     updateModel,
     publishPublic,
+    editMode,
   } = props;
 
   const [isUpdating, setIsUpdating] = useState(false);
@@ -155,7 +157,7 @@ export function PlatformPublishing(props: PlatformPublishingInternalProps) {
           {platformStatus.status === 'not_published' && (
             <Button
               onClick={handlePublishDraft}
-              disabled={isPublishing}
+              disabled={editMode || isPublishing}
               className="w-full"
             >
               {isPublishing ? 'Publishing Draft...' : `Publish Draft to ${platformName}`}
@@ -185,7 +187,7 @@ export function PlatformPublishing(props: PlatformPublishingInternalProps) {
               <div className="flex space-x-2">
                 <Button
                   onClick={handleUpdateModel}
-                  disabled={isUpdating || isPublishing}
+                  disabled={editMode || isUpdating || isPublishing}
                   className="flex-1"
                   variant="outline"
                 >
@@ -193,7 +195,7 @@ export function PlatformPublishing(props: PlatformPublishingInternalProps) {
                 </Button>
                 <Button
                   onClick={handlePublishPublic}
-                  disabled={isUpdating || isPublishing}
+                  disabled={editMode || isUpdating || isPublishing}
                   className="flex-1"
                 >
                   {isPublishing ? "Publishing..." : "Publish to Public"}
@@ -225,7 +227,7 @@ export function PlatformPublishing(props: PlatformPublishingInternalProps) {
               <div className="flex space-x-2">
                 <Button
                   onClick={handleUpdateModel}
-                  disabled={isUpdating}
+                  disabled={editMode || isUpdating}
                   className="flex-1"
                   variant="outline"
                 >

--- a/src/app/components/ui/site-header.tsx
+++ b/src/app/components/ui/site-header.tsx
@@ -14,13 +14,27 @@ export function SiteHeader() {
         setShowProfiles(window.name === '') // Hide in (named) popup windows
     }, []);
 
+    // Intercept dashboard navigation if editing
+    const handleDashboardClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+        // Check for edit mode flag on window (set by the design page)
+        // @ts-expect-error might not exist
+        if (window.__pubman_isEditing) {
+            const confirmLeave = window.confirm('You have unsaved changes. Are you sure you want to leave?');
+            if (!confirmLeave) {
+                e.preventDefault();
+                return;
+            }
+        }
+        redirect('/dashboard');
+    };
+
     return (
         <header className="border-grid sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
             <div className="flex h-16 items-center justify-between px-4">
                 <div className="flex items-center space-x-4">
                     <h1 className="text-xl font-bold">Pubman</h1>
                     <nav className={`${!showDashboard ? 'hidden' : ''}`}>
-                        <a className="text-sm font-bold text-gray-700 hover:text-gray-900" onClick={() => redirect('/dashboard')}>Return to Dashboard</a>
+                        <a className="text-sm font-bold text-gray-700 hover:text-gray-900" onClick={handleDashboardClick}>Return to Dashboard</a>
                     </nav>
                 </div>
                 <div className="flex-1"></div>

--- a/src/app/design/[designID]/page.tsx
+++ b/src/app/design/[designID]/page.tsx
@@ -76,6 +76,30 @@ const DesignDetailsPage = () => {
     fetch();
   }, [designID]);
 
+  useEffect(() => {
+    // Warn on browser/tab close or reload if editing
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (editMode) {
+        e.preventDefault();
+        e.returnValue = '';
+      }
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    // Set/unset global edit flag for navigation guards
+    if (editMode) {
+      // @ts-expect-error global var
+      window.__pubman_isEditing = true;
+    } else {
+      // @ts-expect-error global var
+      window.__pubman_isEditing = false;
+    }
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      // @ts-expect-error global var
+      window.__pubman_isEditing = false;
+    };
+  }, [editMode]);
+
   const onSubmit = async (data: FieldValues) => {
     if (!design) return;
 
@@ -431,6 +455,7 @@ const DesignDetailsPage = () => {
           setErrorMessage={setErrorMessage}
           setSuccessMessage={setSuccessMessage}
           onDesignUpdated={(updatedDesign) => setDesign(updatedDesign)}
+          editMode={editMode}
         />
       )}
 
@@ -442,6 +467,7 @@ const DesignDetailsPage = () => {
           setErrorMessage={setErrorMessage}
           setSuccessMessage={setSuccessMessage}
           onDesignUpdated={(updateDesign) => setDesign(updateDesign)}
+          editMode={editMode}
         />
       )}
 
@@ -453,6 +479,7 @@ const DesignDetailsPage = () => {
           setErrorMessage={setErrorMessage}
           setSuccessMessage={setSuccessMessage}
           onDesignUpdated={(updatedDesign) => setDesign(updatedDesign)}
+          editMode={editMode}
         />
       )}
 


### PR DESCRIPTION
Relates to #69 

This pull request introduces changes to enhance user experience and prevent data loss when editing designs. The updates include adding navigation guards, modifying button states based on edit mode, and introducing an `editMode` prop to manage editing-related behaviors across components.

### Navigation Guards and Edit Mode Management:

* [`src/app/components/design/design-form.tsx`](diffhunk://#diff-86b1f63e1fcbbec48be1871d62da18b8d35d967b2a9f8a11104a5050427e6418R51-R66): Added a `useEffect` hook to set a global `__pubman_isEditing` flag and warn users about unsaved changes when navigating away or closing the browser/tab.
* [`src/app/components/ui/site-header.tsx`](diffhunk://#diff-60dad903429765bd01e43d1081242645e53349f8e4eb1a167a6fcd8a57877e63R17-R37): Updated dashboard navigation to prompt users with a confirmation dialog if they have unsaved changes.
* `src/app/design/[designID]/page.tsx`: Added a `useEffect` hook to manage the `__pubman_isEditing` flag and warn users about unsaved changes during navigation or tab/browser closure. ([src/app/design/[designID]/page.tsxR79-R102](diffhunk://#diff-e5d71b2ae3401b831dde9fd8e67cf5059bbc46fbca2c251f91dda8f94febe68bR79-R102))

### Button State Updates:

* [`src/app/components/design/platform-publishing.tsx`](diffhunk://#diff-f15d931d327ee7016ae764625bb1c93960846ee7287b79f7d612018f3e701facL158-R160): Modified button states to disable publishing and updating actions when `editMode` is active, ensuring users cannot perform these actions while editing. [[1]](diffhunk://#diff-f15d931d327ee7016ae764625bb1c93960846ee7287b79f7d612018f3e701facL158-R160) [[2]](diffhunk://#diff-f15d931d327ee7016ae764625bb1c93960846ee7287b79f7d612018f3e701facL188-R198) [[3]](diffhunk://#diff-f15d931d327ee7016ae764625bb1c93960846ee7287b79f7d612018f3e701facL228-R230)

### Prop Enhancements:

* [`src/app/components/design/platform-publishing.tsx`](diffhunk://#diff-f15d931d327ee7016ae764625bb1c93960846ee7287b79f7d612018f3e701facR17): Introduced an optional `editMode` prop to control editing-related behaviors.
* `src/app/design/[designID]/page.tsx`: Passed the `editMode` prop to child components to enable consistent edit mode handling. ([src/app/design/[designID]/page.tsxR458](diffhunk://#diff-e5d71b2ae3401b831dde9fd8e67cf5059bbc46fbca2c251f91dda8f94febe68bR458), [src/app/design/[designID]/page.tsxR470](diffhunk://#diff-e5d71b2ae3401b831dde9fd8e67cf5059bbc46fbca2c251f91dda8f94febe68bR470), [src/app/design/[designID]/page.tsxR482](diffhunk://#diff-e5d71b2ae3401b831dde9fd8e67cf5059bbc46fbca2c251f91dda8f94febe68bR482))