### PR TITLE
Character counts for design title and summary

### DIFF
--- a/src/app/components/design/design-form.tsx
+++ b/src/app/components/design/design-form.tsx
@@ -33,6 +33,8 @@ const DesignForm = () => {
   const router = useRouter();
   const [description, setDescription] = useState<string>("");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [titleCount, setTitleCount] = useState(0);
+  const [summaryCount, setSummaryCount] = useState(0);
 
   const form = useForm<DesignCreateSchema>({
     resolver: zodResolver(designCreateSchema),
@@ -56,6 +58,11 @@ const DesignForm = () => {
       window.__pubman_isEditing = false;
     };
   }, []);
+
+  useEffect(() => {
+    setTitleCount(form.getValues('main_name')?.length || 0);
+    setSummaryCount(form.getValues('summary')?.length || 0);
+  }, [form]);
 
   const onSubmit = async (data: DesignCreateSchema) => {
     setErrorMessage(null); // Clear previous errors
@@ -99,8 +106,13 @@ const DesignForm = () => {
                   {...field}
                   required
                   className="border border-gray-300 rounded-md p-2"
+                  onChange={e => {
+                    field.onChange(e);
+                    setTitleCount(e.target.value.length);
+                  }}
                 />
               </FormControl>
+              <div className="text-xs text-gray-500 text-right">{titleCount}</div>
             </FormItem>
           )}
         />
@@ -120,8 +132,13 @@ const DesignForm = () => {
                   {...field}
                   required
                   className="border border-gray-300 rounded-md p-2"
+                  onChange={e => {
+                    field.onChange(e);
+                    setSummaryCount(e.target.value.length);
+                  }}
                 />
               </FormControl>
+              <div className="text-xs text-gray-500 text-right">{summaryCount}</div>
             </FormItem>
           )}
         />

--- a/src/app/design/[designID]/page.tsx
+++ b/src/app/design/[designID]/page.tsx
@@ -45,6 +45,8 @@ const DesignDetailsPage = () => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [editMode, setEditMode] = useState(false);
+  const [titleCount, setTitleCount] = useState(0);
+  const [summaryCount, setSummaryCount] = useState(0);
   const { register, handleSubmit, reset, formState: { errors } } = useForm();
   const router = useRouter();
   const resetForm = (design: DesignSchema) => {
@@ -181,6 +183,13 @@ const DesignDetailsPage = () => {
     }
   };
 
+  useEffect(() => {
+    if (editMode) {
+      setTitleCount(design?.main_name?.length || 0);
+      setSummaryCount(design?.summary?.length || 0);
+    }
+  }, [editMode, design]);
+
   if (!design) return <div>Loading...</div>;
 
   return (
@@ -221,7 +230,12 @@ const DesignDetailsPage = () => {
               {...register('main_name', { required: true })}
               defaultValue={design.main_name}
               className="w-full"
+              onChange={e => {
+                register('main_name').onChange(e);
+                setTitleCount(e.target.value.length);
+              }}
             />
+            <div className="text-xs text-gray-500 text-right">{titleCount} Characters</div>
             {errors.main_name && <p className="text-red-500 text-sm">Name is required</p>}
           </div>
 
@@ -232,7 +246,12 @@ const DesignDetailsPage = () => {
               defaultValue={design.summary}
               className="w-full border rounded-md p-2"
               rows={2}
+              onChange={e => {
+                register('summary').onChange(e);
+                setSummaryCount(e.target.value.length);
+              }}
             />
+            <div className="text-xs text-gray-500 text-right">{summaryCount} Characters</div>
             {errors.summary && <p className="text-red-500 text-sm">Summary is required</p>}
           </div>
           


### PR DESCRIPTION
Relates to #72

This pull request introduces character count tracking for the title and summary fields in both the `DesignForm` and `DesignDetailsPage` components. These changes aim to enhance user experience by providing real-time feedback on the number of characters entered.

Some things that are still missing:
- [ ] Add a note about platform-specific character limits on title and summary
- [ ] Better layout of input field and character counts/platform notes
- [ ] Should these counts appear outside of edit mode as well?