### PR TITLE
MakerWorld supports jpeg+jpg; Consolidate image types

### DIFF
--- a/src/app/api/design/[designID]/route.js
+++ b/src/app/api/design/[designID]/route.js
@@ -13,6 +13,9 @@ const platformMap = {
   5: 'MAKERWORLD'
 }
 
+// TODO: Move this to a shared location
+const pubmanImageFileTypes = ['jpg', 'jpeg', 'png', 'webp', 'gif', 'heic', 'heif', 'svg'];
+
 const PLATFORM_PUBMAN = 1;
 
 export async function GET(request, {params}) {
@@ -89,7 +92,7 @@ export async function GET(request, {params}) {
         tag: tag.tag,
         platform: platformMap[tag.platform_id] || 'UNKNOWN',
       })),
-      thumbnail: assets.filter((asset) => ["jpg", "jpeg", "png"].includes(asset.file_ext.toLowerCase())).map(asset => `local://${asset.file_path}`)[0] || null,
+      thumbnail: assets.filter((asset) => pubmanImageFileTypes.includes(asset.file_ext.toLowerCase())).map(asset => `local://${asset.file_path}`)[0] || null,
       assets: assets.map((asset) => ({
         id: asset.id.toString(),
         file_name: asset.file_name,

--- a/src/app/api/design/route.js
+++ b/src/app/api/design/route.js
@@ -12,6 +12,9 @@ const platformMap = {
   5: 'MAKERWORLD',
 }
 
+// TODO: Move this to a shared location
+const pubmanImageFileTypes = ['jpg', 'jpeg', 'png', 'webp', 'gif', 'heic', 'heif', 'svg'];
+
 const PLATFORM_PUBMAN = 1;
 
 export async function GET(request) {
@@ -89,7 +92,7 @@ export async function GET(request) {
           tag: tag.tag,
           platform: platformMap[tag.platform_id] || 'UNKNOWN',
         })),
-        thumbnail: assets.filter((asset) => ["jpg", "jpeg", "png"].includes(asset.file_ext.toLowerCase())).map(asset => `local://${asset.file_path}`)[0] || null,
+        thumbnail: assets.filter((asset) => pubmanImageFileTypes.includes(asset.file_ext.toLowerCase())).map(asset => `local://${asset.file_path}`)[0] || null,
         assets: assets.map((asset) => ({
           id: asset.id.toString(),
           file_name: asset.file_name,

--- a/src/app/api/makerworld/makerworld-lib.js
+++ b/src/app/api/makerworld/makerworld-lib.js
@@ -112,6 +112,10 @@ export const licenseToMakerWorldMap = {
   'SDFL': 'Standard Digital File License' // Standard Design File License
 };
 
+export const makerWorldImageFileTypes = [
+  'jpg', 'jpeg', 'png', 'gif', 'webp',
+];
+
 export function isPubmanLicenseSupported(pubmanLicense) {
   const license = licenseToMakerWorldMap[pubmanLicense];
   return license in makerWorldLicenses;

--- a/src/app/api/makerworld/makerworld-lib.js
+++ b/src/app/api/makerworld/makerworld-lib.js
@@ -112,9 +112,7 @@ export const licenseToMakerWorldMap = {
   'SDFL': 'Standard Digital File License' // Standard Design File License
 };
 
-export const makerWorldImageFileTypes = [
-  'jpg', 'jpeg', 'png', 'gif', 'webp',
-];
+export const makerWorldImageFileTypes = ['jpg', 'jpeg', 'png', 'gif', 'webp'];
 
 export function isPubmanLicenseSupported(pubmanLicense) {
   const license = licenseToMakerWorldMap[pubmanLicense];

--- a/src/app/api/makerworld/model/route.js
+++ b/src/app/api/makerworld/model/route.js
@@ -3,7 +3,7 @@ import {
   MakerWorldAPI,
   UpdateDraftRequestSchema,
   makerWorldCategories,
-  licenseToMakerWorldMap, MakerWorldAPIError
+  licenseToMakerWorldMap, MakerWorldAPIError, makerWorldImageFileTypes
 } from "../makerworld-lib";
 import log from "electron-log/renderer";
 import { getDatabase } from "../../../lib/betterSqlite3";
@@ -100,7 +100,7 @@ export async function POST(request) {
           const fileBuffer = fs.readFileSync(filePath);
           const uploadResult = await api.uploadFile(asset.file_name, fileBuffer, makerWorldUserId);
           log.info(`Uploaded file: ${asset.file_name}`, uploadResult);
-          if (["jpg", "jpeg", "png"].includes(asset.file_ext.toLowerCase())) {
+          if (makerWorldImageFileTypes.includes(asset.file_ext.toLowerCase())) {
             images.push({
               name: asset.file_name,
               url: uploadResult.url,

--- a/src/app/api/makerworld/model/route.js
+++ b/src/app/api/makerworld/model/route.js
@@ -3,7 +3,9 @@ import {
   MakerWorldAPI,
   UpdateDraftRequestSchema,
   makerWorldCategories,
-  licenseToMakerWorldMap, MakerWorldAPIError, makerWorldImageFileTypes
+  licenseToMakerWorldMap,
+  MakerWorldAPIError,
+  makerWorldImageFileTypes
 } from "../makerworld-lib";
 import log from "electron-log/renderer";
 import { getDatabase } from "../../../lib/betterSqlite3";

--- a/src/app/api/printables/printables-lib.js
+++ b/src/app/api/printables/printables-lib.js
@@ -1,5 +1,7 @@
 import log from 'electron-log/renderer';
 
+export const printablesImageFileTypes = ["gif", "heic", "heif", "jpeg", "jpg", "png", "svg", "webp"];
+
 export const printablesCategories = {
   "3D Printers": {"id": "1", "path": ["3D Printers"], "pathIds": ["1"], "disabled": true},
   "Prusa Parts & Upgrades": {"id": "134", "path": ["3D Printers", "Prusa Parts & Upgrades"], "pathIds": ["1", "134"]},

--- a/src/app/components/design/makerworld-publishing.tsx
+++ b/src/app/components/design/makerworld-publishing.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { PlatformPublishing, PlatformPublishingProps } from "./platform-publishing";
-import { isPubmanLicenseSupported } from "@/src/app/api/makerworld/makerworld-lib";
+import {isPubmanLicenseSupported, makerWorldImageFileTypes} from "@/src/app/api/makerworld/makerworld-lib";
 import { useMakerWorldAuth } from "@/src/app/contexts/MakerWorldAuthContext";
 import log from 'electron-log/renderer';
 
@@ -40,7 +40,7 @@ export function MakerWorldPublishing(props: PlatformPublishingProps) {
           return false;
         }
         const hasImages = design.assets.some(asset =>
-          ["png", "jpg", "webp", "gif"].includes(asset.file_ext.toLowerCase())
+          makerWorldImageFileTypes.includes(asset.file_ext.toLowerCase())
         );
         if (!hasImages) {
           setErrorMessage("You need to add at least one image before publishing to MakerWorld");

--- a/src/app/components/design/makerworld-publishing.tsx
+++ b/src/app/components/design/makerworld-publishing.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { PlatformPublishing, PlatformPublishingProps } from "./platform-publishing";
-import {isPubmanLicenseSupported, makerWorldImageFileTypes} from "@/src/app/api/makerworld/makerworld-lib";
+import { isPubmanLicenseSupported, makerWorldImageFileTypes } from "@/src/app/api/makerworld/makerworld-lib";
 import { useMakerWorldAuth } from "@/src/app/contexts/MakerWorldAuthContext";
 import log from 'electron-log/renderer';
 

--- a/src/app/components/design/printables-publishing.tsx
+++ b/src/app/components/design/printables-publishing.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { PlatformPublishing, PlatformPublishingProps } from "./platform-publishing";
-import { printablesIsLicenseSupported } from "@/src/app/api/printables/printables-lib";
+import {printablesImageFileTypes, printablesIsLicenseSupported} from "@/src/app/api/printables/printables-lib";
 import { usePrintablesAuth } from "@/src/app/contexts/PrintablesAuthContext";
 
 export function PrintablesPublishing(props: PlatformPublishingProps) {
@@ -37,7 +37,7 @@ export function PrintablesPublishing(props: PlatformPublishingProps) {
           return false;
         }
         const hasImages = design.assets.some(asset =>
-          ["gif", "heic", "heif", "jpeg", "jpg", "png", "svg", "webp"].includes(asset.file_ext.toLowerCase())
+          printablesImageFileTypes.includes(asset.file_ext.toLowerCase())
         );
         if (!hasImages) {
           setErrorMessage("You need to add at least one image before publishing to Printables");

--- a/src/app/components/design/printables-publishing.tsx
+++ b/src/app/components/design/printables-publishing.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { PlatformPublishing, PlatformPublishingProps } from "./platform-publishing";
-import {printablesImageFileTypes, printablesIsLicenseSupported} from "@/src/app/api/printables/printables-lib";
+import { printablesImageFileTypes, printablesIsLicenseSupported } from "@/src/app/api/printables/printables-lib";
 import { usePrintablesAuth } from "@/src/app/contexts/PrintablesAuthContext";
 
 export function PrintablesPublishing(props: PlatformPublishingProps) {


### PR DESCRIPTION
This pull request introduces reusable constants for image file types across multiple modules to improve maintainability and consistency. It replaces hardcoded arrays of file extensions with shared constants and updates their usage in various parts of the codebase.

It also fixes a bug in MakerWorld publishing, where `jpeg` images weren't allowed to be published.

Closes #79