### PR TITLE
Fix opaque errors and runaway retries on MakerWorld's daily download limit

### DIFF
--- a/src/app/components/dashboard/makerworld-sync.tsx
+++ b/src/app/components/dashboard/makerworld-sync.tsx
@@ -15,6 +15,7 @@ import {
   MakerWorldClientAPIError,
   getLicenseDisplayName,
   licensesAreEqual,
+  isDailyDownloadLimitError,
 } from "../../lib/makerworld-client";
 import log from "electron-log/renderer";
 import { RefreshCw, Check, Download, AlertCircle, ExternalLink, GitMerge, ChevronDown, Settings2 } from "lucide-react";
@@ -92,6 +93,8 @@ interface SyncState {
   failed: Array<{ id: number; name: string; error: string }>;
   skipped: Array<{ id: number; name: string; reason: string }>;
   captcha: CaptchaState | null;
+  // Set when MakerWorld's daily download-link quota is hit; sync stops entirely (see syncDesigns)
+  dailyLimitReached: boolean;
   // Sync options
   syncOptions: SyncOptions;
   // Merge handling - maps MakerWorld design ID to merge config
@@ -141,6 +144,7 @@ export function MakerWorldSync({
     failed: [],
     skipped: [],
     captcha: null,
+    dailyLimitReached: false,
     syncOptions: {
       downloadCoverImages: true,
       downloadModelFiles: true,
@@ -161,6 +165,8 @@ export function MakerWorldSync({
   const cancelledRef = useRef(false);
   // Ref to track if captcha was required (to break out of sync loop)
   const captchaRequiredRef = useRef(false);
+  // Ref to track if MakerWorld's daily download limit was hit (to break out of sync loop)
+  const dailyLimitRef = useRef(false);
 
   const fetchDesigns = useCallback(async (userHandle: string, userId?: number) => {
     setState((prev) => ({ ...prev, isFetching: true, error: null }));
@@ -233,6 +239,7 @@ export function MakerWorldSync({
         failed: [],
         skipped: [],
         syncCancelled: false,
+        dailyLimitReached: false,
         mergeConfigs: new Map(),
         showSummary: false,
         mergePreviewDesignId: null,
@@ -301,6 +308,13 @@ export function MakerWorldSync({
     setState((prev) => ({
       ...prev,
       captcha: null,
+    }));
+  };
+
+  const dismissDailyLimit = () => {
+    setState((prev) => ({
+      ...prev,
+      dailyLimitReached: false,
     }));
   };
 
@@ -606,6 +620,7 @@ export function MakerWorldSync({
     }));
     cancelledRef.current = false;
     captchaRequiredRef.current = false;
+    dailyLimitRef.current = false;
 
     setState((prev) => ({
       ...prev,
@@ -720,6 +735,7 @@ export function MakerWorldSync({
         const assets: Array<{ fileName: string; fileExt: string; filePath: string; fileSize?: number }> = [];
         const failedDownloads: string[] = [];  // Track which files failed to download
         let captchaRequired = false;
+        let dailyLimitReached = false;
 
         // Estimate total files for progress tracking
         const instances = designDetails?.instances || [];
@@ -809,6 +825,9 @@ export function MakerWorldSync({
             if (isCaptchaError(modelError)) {
               log.warn(`[MakerWorld Sync] Captcha required for model download URL`);
               captchaRequired = true;
+            } else if (isDailyDownloadLimitError(modelError)) {
+              log.error(`[MakerWorld Sync] MakerWorld daily download limit reached while fetching model download URL`);
+              dailyLimitReached = true;
             } else {
               const errorMsg = modelError instanceof Error ? modelError.message : 'unknown error';
               log.warn(`[MakerWorld Sync] Failed to fetch model download URL:`, modelError);
@@ -819,6 +838,15 @@ export function MakerWorldSync({
           log.info(`[MakerWorld Sync] No model files in design ${design.id} - will use instance downloads`);
         } else {
           log.info(`[MakerWorld Sync] Skipping model files download (disabled in options)`);
+        }
+
+        // If the daily download-link quota is used up, every further getModelDownloadUrl/
+        // getInstanceDownloadUrl call will fail identically - stop the ENTIRE sync now
+        // instead of hammering MakerWorld's API once per remaining design.
+        if (dailyLimitReached) {
+          dailyLimitRef.current = true;
+          setState((prev) => ({ ...prev, isSyncing: false, dailyLimitReached: true }));
+          throw new Error("MAKERWORLD_DAILY_LIMIT_REACHED");
         }
 
         // If captcha required, pause and prompt user - break out of sync loop
@@ -874,6 +902,10 @@ export function MakerWorldSync({
                   log.warn(`[MakerWorld Sync] Captcha required for instance ${instance.id} 3MF download URL`);
                   captchaRequired = true;
                   break;
+                } else if (isDailyDownloadLimitError(instanceError)) {
+                  log.error(`[MakerWorld Sync] MakerWorld daily download limit reached while fetching instance ${instance.id} 3MF download URL`);
+                  dailyLimitReached = true;
+                  break;
                 } else {
                   const errorMsg = instanceError instanceof Error ? instanceError.message : 'unknown error';
                   log.warn(`[MakerWorld Sync] Failed to fetch instance ${instance.id} 3MF:`, instanceError);
@@ -882,6 +914,14 @@ export function MakerWorldSync({
               }
             }
           }
+        }
+
+        // If the daily download-link quota is used up, stop the ENTIRE sync now (see the
+        // comment on the identical check above, after the model-files download step).
+        if (dailyLimitReached) {
+          dailyLimitRef.current = true;
+          setState((prev) => ({ ...prev, isSyncing: false, dailyLimitReached: true }));
+          throw new Error("MAKERWORLD_DAILY_LIMIT_REACHED");
         }
 
         // If captcha required, pause and prompt user
@@ -1071,6 +1111,26 @@ export function MakerWorldSync({
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "Unknown error";
 
+        // Check if the daily download limit was hit - if so, stop the whole sync (every
+        // remaining design would just fail the exact same way) rather than treating it as
+        // a per-design failure and continuing to hammer MakerWorld's API.
+        if (dailyLimitRef.current || errorMessage === "MAKERWORLD_DAILY_LIMIT_REACHED") {
+          log.error(`[MakerWorld Sync] Daily download limit reached - stopping sync`);
+          const remainingDesigns = designsToSync.slice(designIndex);
+          setState((prev) => ({
+            ...prev,
+            skipped: [
+              ...prev.skipped,
+              ...remainingDesigns.map((d) => ({
+                id: d.id,
+                name: d.title,
+                reason: "MakerWorld daily download limit reached - sync stopped",
+              })),
+            ],
+          }));
+          break;
+        }
+
         // Check if this was a captcha error - if so, skip remaining designs and break
         if (captchaRequiredRef.current || errorMessage === "CAPTCHA_REQUIRED") {
           log.info(`[MakerWorld Sync] Captcha required - pausing sync`);
@@ -1098,8 +1158,8 @@ export function MakerWorldSync({
       }
     }
 
-    // Only show summary if we didn't pause for captcha
-    if (!captchaRequiredRef.current) {
+    // Only show summary if we didn't pause for captcha or stop for a daily limit
+    if (!captchaRequiredRef.current && !dailyLimitRef.current) {
       setState((prev) => ({ ...prev, isSyncing: false, showSummary: true }));
     }
 
@@ -1343,6 +1403,35 @@ export function MakerWorldSync({
                       size="sm"
                       onClick={dismissCaptcha}
                       className="border-amber-300 text-amber-700 hover:bg-amber-100"
+                    >
+                      Dismiss
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Daily Download Limit Alert - shown when MakerWorld's download-link quota is hit */}
+          {state.dailyLimitReached && (
+            <div className="mt-3 p-4 bg-red-50 border border-red-200 rounded-lg">
+              <div className="flex items-start">
+                <AlertCircle className="h-5 w-5 text-red-600 mr-3 mt-0.5 flex-shrink-0" />
+                <div className="flex-1">
+                  <h3 className="font-medium text-red-800">MakerWorld Daily Download Limit Reached</h3>
+                  <p className="text-sm text-red-700 mt-1">
+                    MakerWorld limits how many download links it will issue per account each day.
+                    Sync has been stopped so it doesn&apos;t keep hitting that limit. Any
+                    remaining designs were skipped - reopen this dialog and sync again once the
+                    limit resets (MakerWorld doesn&apos;t publish an exact reset time, but it is
+                    generally daily).
+                  </p>
+                  <div className="mt-3">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={dismissDailyLimit}
+                      className="border-red-300 text-red-700 hover:bg-red-100"
                     >
                       Dismiss
                     </Button>

--- a/src/app/lib/makerworld-client.test.js
+++ b/src/app/lib/makerworld-client.test.js
@@ -1,0 +1,51 @@
+import { MakerWorldClientAPIError, isDailyDownloadLimitError } from './makerworld-client';
+
+describe('isDailyDownloadLimitError', () => {
+  it('detects the real BambuLab daily-limit error shape', () => {
+    const error = new MakerWorldClientAPIError({
+      message: 'MakerWorld API error: 400 Bad Request',
+      responseStatus: 400,
+      responseBody: JSON.stringify({ code: -1, error: "You've reached your daily download limit." }),
+    });
+    expect(isDailyDownloadLimitError(error)).toBe(true);
+  });
+
+  it('is case-insensitive about the message wording', () => {
+    const error = new MakerWorldClientAPIError({
+      message: 'MakerWorld API error: 400 Bad Request',
+      responseStatus: 400,
+      responseBody: JSON.stringify({ code: -1, error: 'Daily Download Limit exceeded' }),
+    });
+    expect(isDailyDownloadLimitError(error)).toBe(true);
+  });
+
+  it('does not match an unrelated 400 error', () => {
+    const error = new MakerWorldClientAPIError({
+      message: 'MakerWorld API error: 400 Bad Request',
+      responseStatus: 400,
+      responseBody: JSON.stringify({ code: -2, error: 'Invalid design ID' }),
+    });
+    expect(isDailyDownloadLimitError(error)).toBe(false);
+  });
+
+  it('does not match the same message on a different status code', () => {
+    const error = new MakerWorldClientAPIError({
+      message: 'MakerWorld API error: 500 Internal Server Error',
+      responseStatus: 500,
+      responseBody: JSON.stringify({ code: -1, error: "You've reached your daily download limit." }),
+    });
+    expect(isDailyDownloadLimitError(error)).toBe(false);
+  });
+
+  it('does not match when there is no response body', () => {
+    const error = new MakerWorldClientAPIError({
+      message: 'MakerWorld API error: 400 Bad Request',
+      responseStatus: 400,
+    });
+    expect(isDailyDownloadLimitError(error)).toBe(false);
+  });
+
+  it('does not match a plain Error', () => {
+    expect(isDailyDownloadLimitError(new Error("You've reached your daily download limit."))).toBe(false);
+  });
+});

--- a/src/app/lib/makerworld-client.ts
+++ b/src/app/lib/makerworld-client.ts
@@ -203,6 +203,40 @@ export class MakerWorldClientAPIError extends Error {
   }
 }
 
+/**
+ * Pulls a human-readable message out of a MakerWorld/BambuLab JSON error body
+ * (typically shaped like {code, error} or {code, message}). Returns undefined if the
+ * body isn't JSON or doesn't have a recognizable message field.
+ */
+function extractApiErrorDetail(responseBody?: string): string | undefined {
+  if (!responseBody) return undefined;
+  try {
+    const parsed = JSON.parse(responseBody);
+    if (typeof parsed?.error === 'string') return parsed.error;
+    if (typeof parsed?.message === 'string') return parsed.message;
+  } catch {
+    // Not JSON - nothing to extract.
+  }
+  return undefined;
+}
+
+/**
+ * True when `error` is a MakerWorldClientAPIError reporting that the account's daily
+ * download-link quota has been used up. BambuLab returns this as HTTP 400 with a body
+ * like {"code":-1,"error":"You've reached your daily download limit."} - there's no
+ * client-side workaround, and every further getModelDownloadUrl/getInstanceDownloadUrl
+ * call will keep failing the exact same way until the quota resets, so callers should
+ * stop retrying entirely rather than treating it like a per-file failure.
+ */
+export function isDailyDownloadLimitError(error: unknown): boolean {
+  return (
+    error instanceof MakerWorldClientAPIError &&
+    error.responseStatus === 400 &&
+    typeof error.responseBody === 'string' &&
+    /download limit/i.test(error.responseBody)
+  );
+}
+
 // MakerWorld draft status codes
 export const MAKERWORLD_STATUS = {
   0: 'new',
@@ -282,8 +316,14 @@ export class MakerWorldClientAPI {
     }
 
     if (!response.ok) {
+      // MakerWorld/BambuLab error responses are typically {code, error} JSON bodies with a
+      // human-readable message (e.g. rate limits, quota errors) - surface that instead of
+      // just the bare HTTP status, which by itself gives no actionable information.
+      const detail = extractApiErrorDetail(response.body);
       const error = new MakerWorldClientAPIError({
-        message: `MakerWorld API error: ${response.status} ${response.statusText}`,
+        message: detail
+          ? `MakerWorld API error: ${response.status} ${response.statusText} - ${detail}`
+          : `MakerWorld API error: ${response.status} ${response.statusText}`,
         url,
         method,
         requestBody: options.body,


### PR DESCRIPTION
## Summary
- Syncing many designs from MakerWorld can hit BambuLab's daily download-link quota (`HTTP 400`, `{"code":-1,"error":"You've reached your daily download limit."}`), returned from `getModelDownloadUrl`/`getInstanceDownloadUrl`.
- Previously this surfaced as an opaque `MakerWorld API error: 400 Bad Request` and the sync loop just moved on to the next design — hitting the same limit again immediately for every remaining design.
- `MakerWorldClientAPI` now extracts `{error}`/`{message}` from failing JSON response bodies and includes it in the thrown error's message, so any MakerWorld API error is self-explanatory instead of a bare status code.
- Added `isDailyDownloadLimitError()` and wired it into `MakerWorldSync`'s per-design download loop, mirroring the existing CAPTCHA-pause pattern: the whole sync stops immediately (instead of hammering the endpoint for every remaining design), remaining designs are marked skipped with a clear reason, and a dismissible red banner explains what happened.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx eslint` on both changed files — clean
- [x] `npx jest` — all 8 suites / 32 tests pass, including a new `makerworld-client.test.js` covering `isDailyDownloadLimitError` (real BambuLab error shape, case-insensitivity, non-matching 400s, same message on a different status code, missing body, non-MakerWorld errors)
- [x] Manually reproduced the original opaque-400 behavior by inspection of the code path, confirmed the fix takes the new branch instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)