### PR TITLE
Add silent token refresh for Printables

### DIFF
--- a/db/migrations-006.txt
+++ b/db/migrations-006.txt
@@ -1,0 +1,6 @@
+-- Migration 006: Add refresh_token + expiry tracking to auth_tokens, enabling silent
+-- token refresh for OAuth providers whose token exchange returns a refresh_token
+-- (currently Printables; Thingiverse's OAuth API never issues a refresh_token, for any
+-- grant type, so it has nothing to store here).
+ALTER TABLE auth_tokens ADD COLUMN refresh_token TEXT;
+ALTER TABLE auth_tokens ADD COLUMN expires_at TEXT;

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -8,8 +8,16 @@ jest.mock('next/server', () => ({
   }
 }));
 
-// Mock electron-log
+// Mock electron-log. Server-side code (API routes, 'use server' actions) uses
+// electron-log/node - electron-log/renderer is only correct in actual renderer-process
+// code (React components/contexts) and is mocked separately for those.
 jest.mock('electron-log/renderer', () => ({
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+}));
+jest.mock('electron-log/node', () => ({
   error: jest.fn(),
   warn: jest.fn(),
   info: jest.fn(),

--- a/src/app/api/printables/auth/callback/save/route.js
+++ b/src/app/api/printables/auth/callback/save/route.js
@@ -44,8 +44,18 @@ export async function GET(request) {
       return NextResponse.json({ error: 'Access token not provided by OAuth server' }, { status: 500 });
     }
 
+    // Prusa3D's token endpoint also returns a refresh_token + expires_in (seconds) -
+    // store both so /api/printables/auth/refresh can silently renew the access token
+    // later instead of forcing the user through the interactive login popup again.
+    const refreshToken = data.refresh_token || null;
+    const expiresAt = typeof data.expires_in === 'number'
+      ? new Date(Date.now() + data.expires_in * 1000).toISOString()
+      : null;
+
     // Store token in database
-    await db.prepare('INSERT OR REPLACE INTO auth_tokens (provider, token) VALUES (?, ?)').run('printables', accessToken);
+    await db.prepare(
+      'INSERT OR REPLACE INTO auth_tokens (provider, token, refresh_token, expires_at) VALUES (?, ?, ?, ?)'
+    ).run('printables', accessToken, refreshToken, expiresAt);
 
     return NextResponse.json({
       message: 'Authentication successful',

--- a/src/app/api/printables/auth/refresh/refresh-POST.test.js
+++ b/src/app/api/printables/auth/refresh/refresh-POST.test.js
@@ -1,6 +1,6 @@
 import { POST } from './route';
 import { getDatabase } from '../../../../lib/betterSqlite3';
-import log from 'electron-log/renderer';
+import log from 'electron-log/node';
 
 jest.mock('../../../../lib/betterSqlite3', () => ({
   getDatabase: jest.fn(),

--- a/src/app/api/printables/auth/refresh/refresh-POST.test.js
+++ b/src/app/api/printables/auth/refresh/refresh-POST.test.js
@@ -1,0 +1,125 @@
+import { POST } from './route';
+import { getDatabase } from '../../../../lib/betterSqlite3';
+import log from 'electron-log/renderer';
+
+jest.mock('../../../../lib/betterSqlite3', () => ({
+  getDatabase: jest.fn(),
+}));
+
+function mockDb({ storedRefreshToken = 'stored-refresh-token' } = {}) {
+  const get = jest.fn().mockReturnValue(storedRefreshToken ? { refresh_token: storedRefreshToken } : undefined);
+  const run = jest.fn();
+  const prepare = jest.fn(() => ({ get, run }));
+  getDatabase.mockReturnValue({ prepare });
+  return { prepare, get, run };
+}
+
+describe('POST /api/printables/auth/refresh', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  it('returns 404 and does not call the token endpoint when no refresh token is stored', async () => {
+    const { run } = mockDb({ storedRefreshToken: null });
+
+    const response = await POST();
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: 'No refresh token available - user must log in again',
+      requiresReauth: true,
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('refreshes successfully and stores the new access token, refresh token, and expiry', async () => {
+    const { prepare, run } = mockDb({ storedRefreshToken: 'old-refresh-token' });
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+        expires_in: 7200,
+        token_type: 'Bearer',
+      }),
+    });
+
+    const response = await POST();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://account.prusa3d.com/o/token/',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.any(URLSearchParams),
+      })
+    );
+    const sentBody = global.fetch.mock.calls[0][1].body;
+    expect(sentBody.get('grant_type')).toBe('refresh_token');
+    expect(sentBody.get('refresh_token')).toBe('old-refresh-token');
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.token).toBe('new-access-token');
+    expect(typeof body.expiresAt).toBe('string');
+
+    expect(prepare).toHaveBeenCalledWith(expect.stringContaining('INSERT OR REPLACE'));
+    expect(run).toHaveBeenCalledWith('printables', 'new-access-token', 'new-refresh-token', expect.any(String));
+  });
+
+  it('carries the existing refresh token forward when the server does not rotate it', async () => {
+    const { run } = mockDb({ storedRefreshToken: 'old-refresh-token' });
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: 'new-access-token', expires_in: 7200 }),
+    });
+
+    await POST();
+
+    expect(run).toHaveBeenCalledWith('printables', 'new-access-token', 'old-refresh-token', expect.any(String));
+  });
+
+  it('clears stored tokens and returns 401 when the refresh token is rejected', async () => {
+    const { run } = mockDb({ storedRefreshToken: 'dead-refresh-token' });
+    global.fetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: 'invalid_grant' }),
+    });
+
+    const response = await POST();
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      error: 'Refresh token expired or revoked',
+      requiresReauth: true,
+    });
+    expect(run).toHaveBeenCalledWith('printables');
+    expect(log.error).toHaveBeenCalled();
+  });
+
+  it('returns 500 if the OAuth server responds ok but omits the access token', async () => {
+    mockDb({ storedRefreshToken: 'old-refresh-token' });
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ expires_in: 7200 }),
+    });
+
+    const response = await POST();
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: 'Access token not provided by OAuth server' });
+  });
+
+  it('returns 500 on unexpected errors', async () => {
+    getDatabase.mockImplementation(() => {
+      throw new Error('db unavailable');
+    });
+
+    const response = await POST();
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: 'Internal server error' });
+  });
+});

--- a/src/app/api/printables/auth/refresh/route.js
+++ b/src/app/api/printables/auth/refresh/route.js
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server';
+import { getDatabase } from "../../../../lib/betterSqlite3";
+import log from "electron-log/renderer";
+
+export async function POST() {
+  try {
+    const db = getDatabase();
+    const row = db.prepare(
+      'SELECT refresh_token FROM auth_tokens WHERE provider = ? ORDER BY updated_at DESC, created_at DESC'
+    ).get('printables');
+
+    if (!row || !row.refresh_token) {
+      return NextResponse.json(
+        { error: 'No refresh token available - user must log in again', requiresReauth: true },
+        { status: 404 }
+      );
+    }
+
+    const url = 'https://account.prusa3d.com/o/token/';
+    const clientId = 'oamhmhZez7opFosnwzElIgE2oGgI2iJORSkw587O'; // PrusaSlicer
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: row.refresh_token,
+        client_id: clientId,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      log.error('Printables token refresh failed:', errorData);
+      // The refresh token itself is dead (expired/revoked) - clear stored tokens so
+      // callers know to fall back to the interactive login popup rather than looping
+      // on a refresh that will never succeed.
+      db.prepare('DELETE FROM auth_tokens WHERE provider = ?').run('printables');
+      return NextResponse.json(
+        { error: 'Refresh token expired or revoked', requiresReauth: true },
+        { status: 401 }
+      );
+    }
+
+    const data = await response.json();
+    log.info('Printables token refresh response:', data);
+    const accessToken = data.access_token;
+    if (!accessToken) {
+      log.error('Access token missing in refresh response:', data);
+      return NextResponse.json({ error: 'Access token not provided by OAuth server' }, { status: 500 });
+    }
+
+    // Some OAuth servers rotate the refresh_token on every use, others return the same
+    // one back (or omit it) - keep the new one if given, otherwise carry the existing
+    // one forward so a future refresh still has something to use.
+    const newRefreshToken = data.refresh_token || row.refresh_token;
+    const expiresAt = typeof data.expires_in === 'number'
+      ? new Date(Date.now() + data.expires_in * 1000).toISOString()
+      : null;
+
+    db.prepare(
+      'INSERT OR REPLACE INTO auth_tokens (provider, token, refresh_token, expires_at) VALUES (?, ?, ?, ?)'
+    ).run('printables', accessToken, newRefreshToken, expiresAt);
+
+    return NextResponse.json({ success: true, token: accessToken, expiresAt });
+  } catch (error) {
+    log.error('Printables token refresh error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/printables/auth/refresh/route.js
+++ b/src/app/api/printables/auth/refresh/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getDatabase } from "../../../../lib/betterSqlite3";
+import { formatApiError } from "../../../../lib/logApiError.js";
 import log from "electron-log/renderer";
 
 export async function POST() {
@@ -66,7 +67,7 @@ export async function POST() {
 
     return NextResponse.json({ success: true, token: accessToken, expiresAt });
   } catch (error) {
-    log.error('Printables token refresh error:', error);
+    log.error('Printables token refresh error:', formatApiError(error));
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/src/app/api/printables/auth/refresh/route.js
+++ b/src/app/api/printables/auth/refresh/route.js
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getDatabase } from "../../../../lib/betterSqlite3";
 import { formatApiError } from "../../../../lib/logApiError.js";
-import log from "electron-log/renderer";
+import log from "electron-log/node";
 
 export async function POST() {
   try {

--- a/src/app/api/printables/auth/token/route.js
+++ b/src/app/api/printables/auth/token/route.js
@@ -5,12 +5,17 @@ import log from "electron-log/renderer";
 export async function GET() {
   try {
     const db = getDatabase();
-    const row = await db.prepare('SELECT token FROM auth_tokens WHERE provider = ? ORDER BY updated_at DESC, created_at DESC').get('printables');
+    const row = await db.prepare(
+      'SELECT token, expires_at FROM auth_tokens WHERE provider = ? ORDER BY updated_at DESC, created_at DESC'
+    ).get('printables');
 
     if (row) {
-      return NextResponse.json({ token: row.token });
+      // expiresAt lets the client (PrintablesAuthContext) decide whether to call
+      // /api/printables/auth/refresh before using this token, instead of waiting for a
+      // 401 from Printables itself.
+      return NextResponse.json({ token: row.token, expiresAt: row.expires_at });
     } else {
-      return NextResponse.json({ token: null });
+      return NextResponse.json({ token: null, expiresAt: null });
     }
   } catch (error) {
     log.error('Failed to get token:', error);

--- a/src/app/contexts/PrintablesAuthContext.tsx
+++ b/src/app/contexts/PrintablesAuthContext.tsx
@@ -24,10 +24,36 @@ interface PrintablesAuthContextType {
 
 const PrintablesAuthContext = createContext<PrintablesAuthContextType | undefined>(undefined);
 
+// Refresh proactively once the access token is within this long of expiring, rather than
+// waiting for Printables to actually reject it.
+const REFRESH_MARGIN_MS = 5 * 60 * 1000;
+// How often to re-check while the app is open, so a long-lived session refreshes itself
+// silently instead of sitting on a stale token between user actions (Printables access
+// tokens are short-lived - ~2 hours as of this writing).
+const RECHECK_INTERVAL_MS = 5 * 60 * 1000;
+
 export function PrintablesAuthProvider({ children }: { children: ReactNode }) {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [user, setUser] = useState<PrintablesUser | null>(null);
   const [accessToken, setAccessToken] = useState<string | null>(null);
+
+  // Exchanges the stored refresh_token for a new access token. Returns null (rather than
+  // throwing) on any failure - callers fall back to whatever token they already had, and
+  // ultimately to prompting a fresh login if that's rejected too.
+  const refreshAccessToken = useCallback(async (): Promise<string | null> => {
+    try {
+      const response = await fetch('/api/printables/auth/refresh', { method: 'POST' });
+      if (!response.ok) {
+        log.warn('Printables token refresh failed - user will need to log in again');
+        return null;
+      }
+      const { token } = await response.json();
+      return token || null;
+    } catch (error) {
+      log.error('Printables token refresh request failed:', error);
+      return null;
+    }
+  }, []);
 
   // Memoize checkAuth so the event listener always gets the latest reference
   const checkAuth = useCallback(async () => {
@@ -36,32 +62,66 @@ export function PrintablesAuthProvider({ children }: { children: ReactNode }) {
       const tokenResponse = await fetch('/api/printables/auth/token');
       if (!tokenResponse.ok) return;
 
-      const { token } = await tokenResponse.json();
+      const { token: initialToken, expiresAt } = await tokenResponse.json();
+      let token = initialToken;
       if (!token) return;
+
+      // Refresh proactively if the token is already expired or close to it, rather than
+      // waiting for Printables to reject a stale one.
+      const isNearExpiry = Boolean(expiresAt) && new Date(expiresAt).getTime() - Date.now() < REFRESH_MARGIN_MS;
+      if (isNearExpiry) {
+        const refreshed = await refreshAccessToken();
+        if (refreshed) {
+          token = refreshed;
+        }
+        // If refresh failed, fall through and try the possibly-stale token anyway - the
+        // retry-on-401 below is the last line of defense.
+      }
 
       setAccessToken(token);
 
       // Then use the token to get user info
-      const response = await fetch('/api/printables/user', {
+      let response = await fetch('/api/printables/user', {
         headers: {
           'x-printables-token': token
         }
       });
+
+      // The proactive expiry check above can miss cases (clock skew, early revocation) -
+      // if Printables itself rejects the token, try refreshing once and retry before
+      // giving up. Skip this if we just refreshed above (isNearExpiry) - no point
+      // refreshing twice in a row.
+      if (response.status === 401 && !isNearExpiry) {
+        const refreshed = await refreshAccessToken();
+        if (refreshed) {
+          token = refreshed;
+          setAccessToken(token);
+          response = await fetch('/api/printables/user', {
+            headers: { 'x-printables-token': token }
+          });
+        }
+      }
 
       if (response.ok) {
         const userData = await response.json();
         log.info('>>> Printables User: {}', userData);
         setUser(userData);
         setIsAuthenticated(true);
+      } else {
+        setUser(null);
+        setIsAuthenticated(false);
       }
     } catch (error) {
       log.error('Failed to check auth status:', error);
     }
-  }, []);
+  }, [refreshAccessToken]);
 
-  // Check for existing auth on mount
+  // Check for existing auth on mount, then periodically re-check so a long-lived session
+  // keeps refreshing itself instead of going stale until the next user action.
   useEffect(() => {
     checkAuth();
+    const interval = setInterval(checkAuth, RECHECK_INTERVAL_MS);
+    return () => clearInterval(interval);
   }, [checkAuth]);
 
   // Listen for PRINTABLES_AUTH_SUCCESS once, on mount

--- a/src/app/lib/logApiError.js
+++ b/src/app/lib/logApiError.js
@@ -1,0 +1,37 @@
+// PubMan's platform API clients (thingiverse-lib.js, printables-lib.js, makerworld-lib.js,
+// makerworld-client.ts) throw errors carrying rich diagnostic detail - either embedded in
+// `.message` as a string, or as separate own-properties (url, method, requestBody,
+// responseStatus, responseStatusText, responseBody, validationIssues) on custom error
+// classes like MakerWorldAPIError. That detail was frequently being captured but never
+// reaching the actual log output, since passing an Error object straight to a logger
+// typically only surfaces `.message`/`.stack`, not arbitrary custom properties.
+//
+// formatApiError renders whichever of these is present, so `log.error(context,
+// formatApiError(error))` always surfaces the full failure detail regardless of which
+// platform/error shape it came from.
+
+const DIAGNOSTIC_KEYS = [
+  'url',
+  'method',
+  'requestBody',
+  'responseStatus',
+  'responseStatusText',
+  'responseBody',
+  'validationIssues',
+];
+
+export function formatApiError(error) {
+  if (!(error instanceof Error)) {
+    if (error === undefined || error === null) return String(error);
+    return typeof error === 'string' ? error : JSON.stringify(error);
+  }
+
+  const parts = [error.message];
+  for (const key of DIAGNOSTIC_KEYS) {
+    const value = error[key];
+    if (value === undefined || value === null) continue;
+    const rendered = typeof value === 'string' ? value : JSON.stringify(value);
+    parts.push(`${key}=${rendered}`);
+  }
+  return parts.join(' | ');
+}

--- a/src/app/lib/logApiError.test.js
+++ b/src/app/lib/logApiError.test.js
@@ -1,0 +1,62 @@
+import { formatApiError } from './logApiError';
+
+describe('formatApiError', () => {
+  it('renders a plain Error as just its message', () => {
+    expect(formatApiError(new Error('boom'))).toBe('boom');
+  });
+
+  it('surfaces diagnostic properties attached to an Error', () => {
+    const error = new Error('Printables API error: https://api.printables.com/graphql/ 401 Unauthorized');
+    error.url = 'https://api.printables.com/graphql/';
+    error.method = 'POST';
+    error.requestBody = { id: '1783880', loadPurchase: false };
+    error.responseStatus = 401;
+    error.responseStatusText = 'Unauthorized';
+    error.responseBody = '{"errors":[{"message":"tag contains invalid characters"}]}';
+
+    const formatted = formatApiError(error);
+    expect(formatted).toContain('Printables API error');
+    expect(formatted).toContain('url=https://api.printables.com/graphql/');
+    expect(formatted).toContain('method=POST');
+    expect(formatted).toContain('requestBody={"id":"1783880","loadPurchase":false}');
+    expect(formatted).toContain('responseStatus=401');
+    expect(formatted).toContain('responseStatusText=Unauthorized');
+    expect(formatted).toContain('responseBody={"errors":[{"message":"tag contains invalid characters"}]}');
+  });
+
+  it('omits keys that are absent, without producing "undefined"/"null" noise', () => {
+    const error = new Error('MakerWorld API error');
+    error.responseStatus = 500;
+    const formatted = formatApiError(error);
+    expect(formatted).toBe('MakerWorld API error | responseStatus=500');
+    expect(formatted).not.toMatch(/undefined|null/);
+  });
+
+  it('handles a MakerWorldAPIError-shaped object (constructed via Object.assign, not a subclass)', () => {
+    const error = Object.assign(new Error('MakerWorld API error'), {
+      name: 'MakerWorldAPIError',
+      url: 'https://api.bambulab.com/v1/design-service/my/draft',
+      method: 'POST',
+      responseStatus: 400,
+      responseStatusText: 'Bad Request',
+      responseBody: '{"code":-1,"error":"validation failed"}',
+      validationIssues: [{ path: 'tags', message: 'invalid character' }],
+    });
+
+    const formatted = formatApiError(error);
+    expect(formatted).toContain('validationIssues=[{"path":"tags","message":"invalid character"}]');
+  });
+
+  it('JSON-stringifies non-Error values rather than relying on default serialization', () => {
+    expect(formatApiError({ status: 500, body: 'oops' })).toBe('{"status":500,"body":"oops"}');
+  });
+
+  it('passes strings through unchanged', () => {
+    expect(formatApiError('plain string error')).toBe('plain string error');
+  });
+
+  it('stringifies null/undefined without throwing', () => {
+    expect(formatApiError(null)).toBe('null');
+    expect(formatApiError(undefined)).toBe('undefined');
+  });
+});


### PR DESCRIPTION
## Summary
- Prusa3D's OAuth token endpoint already returns a `refresh_token` and `expires_in` on every login, but PubMan logged and discarded both, forcing users to redo the interactive login popup roughly every 2 hours (the access token's lifetime).
- Migration `006` adds `refresh_token`/`expires_at` columns to `auth_tokens`.
- `auth/callback/save` now persists the `refresh_token` and computed expiry instead of throwing them away.
- New `POST /api/printables/auth/refresh` exchanges the stored refresh token for a new access token via Prusa3D's `/o/token/` endpoint, carries the existing `refresh_token` forward if the server doesn't rotate it, and clears stored tokens (forcing re-login) if the refresh token itself is rejected.
- `PrintablesAuthContext` now refreshes proactively (`checkAuth` resolves `expiresAt` and refreshes if within 5 minutes of expiry), retries once on an unexpected 401 from Printables, and re-checks every 5 minutes so a long-lived session keeps itself alive without user action.

**Thingiverse is intentionally not touched.** Their OAuth API does not return a `refresh_token` under any grant type — confirmed against their own developer docs, where the `authorization_code` exchange response is documented as just `access_token=...&token_type=bearer`. There's nothing to refresh there; the existing `/api/thingiverse/auth/refresh` route already does the only thing possible (validate the current token, clear it if dead).

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx eslint` on all changed files — clean (aside from one pre-existing, unrelated unused-var warning in `PrintablesAuthContext.tsx`'s `login()`, not touched by this PR)
- [x] `npx jest` — all 8 suites / 32 tests pass, including a new `refresh-POST.test.js` covering: no refresh token stored, successful refresh with token rotation, successful refresh without rotation (old refresh_token carried forward), refresh rejected (tokens cleared, 401), access token missing from an otherwise-ok response, and unexpected errors
- [x] Manually verified end-to-end against a running PubMan dev instance: confirmed migration 006 applies cleanly on both a fresh DB and via the incremental migration runner, confirmed `GET /api/printables/auth/token` returns the new `expiresAt` field, and — using a seeded fake refresh token — confirmed the failure path against Prusa3D's **real, live** OAuth server (`invalid_grant`), which correctly logs the error, clears the stored tokens, and returns a clean 401. The success path is covered by the unit tests since exercising it live requires a real Printables login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)