### PR TITLE
Surface full diagnostic detail on API failures instead of dropping it

### DIFF
--- a/src/app/api/makerworld/auth/page.js
+++ b/src/app/api/makerworld/auth/page.js
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import log from "electron-log/renderer";
+import { formatApiError } from "../../../lib/logApiError.js";
 
 export default function MakerWorldAuthPage() {
   const [step, setStep] = useState("login"); // login | code | done
@@ -39,7 +40,7 @@ export default function MakerWorldAuthPage() {
         setError("Unexpected response from MakerWorld.");
       }
     } catch (err) {
-      log.error("MakerWorld login failed:", err);
+      log.error("MakerWorld login failed:", formatApiError(err));
       setError(err.message || "Login failed");
     } finally {
       setIsSubmitting(false);
@@ -67,7 +68,7 @@ export default function MakerWorldAuthPage() {
         setError("Invalid code or unexpected response.");
       }
     } catch (err) {
-      log.error("MakerWorld code verification failed:", err);
+      log.error("MakerWorld code verification failed:", formatApiError(err));
       setError(err.message || "Code verification failed");
     } finally {
       setIsSubmitting(false);
@@ -95,7 +96,7 @@ export default function MakerWorldAuthPage() {
         setError("TFA verification failed or unexpected response.");
       }
     } catch (err) {
-      log.error("MakerWorld TFA verification failed:", err);
+      log.error("MakerWorld TFA verification failed:", formatApiError(err));
       setError(err.message || "TFA verification failed");
     } finally {
       setIsSubmitting(false);

--- a/src/app/api/makerworld/auth/token/route.js
+++ b/src/app/api/makerworld/auth/token/route.js
@@ -1,6 +1,7 @@
 import {getDatabase} from "../../../../lib/betterSqlite3";
 import {NextResponse} from "next/server";
 import log from "electron-log/renderer";
+import { formatApiError } from "../../../../lib/logApiError.js";
 
 const PROVIDER_NAME = 'makerworld';
 
@@ -15,7 +16,7 @@ export async function GET() {
       return NextResponse.json({ token: null });
     }
   } catch (error) {
-    log.error('Failed to get token:', error);
+    log.error('Failed to get token:', formatApiError(error));
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }
@@ -32,7 +33,7 @@ export async function POST(request) {
     await db.prepare('INSERT OR REPLACE INTO auth_tokens (provider, token) VALUES (?, ?)').run(PROVIDER_NAME, token);
     return NextResponse.json({ success: true });
   } catch (error) {
-    log.error('Failed to save token:', error);
+    log.error('Failed to save token:', formatApiError(error));
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }
@@ -43,7 +44,7 @@ export async function DELETE() {
     await db.prepare('DELETE FROM auth_tokens WHERE provider = ?').run(PROVIDER_NAME);
     return NextResponse.json({ success: true });
   } catch (error) {
-    log.error('Failed to delete token:', error);
+    log.error('Failed to delete token:', formatApiError(error));
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/src/app/api/makerworld/model/record/route.ts
+++ b/src/app/api/makerworld/model/record/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDatabase } from "../../../../lib/betterSqlite3";
 import log from "electron-log/renderer";
+import { formatApiError } from "../../../../lib/logApiError.js";
 
 const MAKERWORLD_PLATFORM_ID = 5;
 const PUBLISHED_STATUS_DRAFT = 1;
@@ -58,7 +59,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ success: true });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    log.error('Failed to record MakerWorld status:', error);
+    log.error('Failed to record MakerWorld status:', formatApiError(error));
     return NextResponse.json({ error: errorMessage }, { status: 500 });
   }
 }

--- a/src/app/api/makerworld/model/route.js
+++ b/src/app/api/makerworld/model/route.js
@@ -12,6 +12,7 @@ import { getDatabase } from "../../../lib/betterSqlite3";
 import {designSchema} from "../../../components/design/types";
 import path from "path";
 import fs from "fs";
+import { formatApiError } from "../../../lib/logApiError.js";
 
 const MAKERWORLD_PLATFORM_ID = 5;
 const PUBLISHED_STATUS_DRAFT = 1;
@@ -118,7 +119,7 @@ export async function POST(request) {
             });
           }
         } catch (error) {
-          log.error(`Failed to upload file ${asset.file_name}:`, error);
+          log.error(`Failed to upload file ${asset.file_name}:`, formatApiError(error));
           return NextResponse.json({ error: 'Some files failed to upload', details: error }, { status: 500 });
         }
       }
@@ -171,7 +172,7 @@ export async function POST(request) {
             }
           } catch (error) {
             if (error instanceof MakerWorldAPIError) {
-              log.error(error.validationIssues);
+              log.error(formatApiError(error));
             }
             lastError = error;
           }
@@ -229,7 +230,7 @@ export async function POST(request) {
       designPlatform
     }, { status: makerWorldId ? 200 : 201 });
   } catch (error) {
-    log.error('Failed to create MakerWorld model:', error);
+    log.error('Failed to create MakerWorld model:', formatApiError(error));
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 }

--- a/src/app/api/makerworld/sync/download/route.ts
+++ b/src/app/api/makerworld/sync/download/route.ts
@@ -6,6 +6,7 @@ import { customAlphabet } from "nanoid";
 import AdmZip from "adm-zip";
 import crypto from "crypto";
 import { getDatabase } from "../../../../lib/betterSqlite3";
+import { formatApiError } from "../../../../lib/logApiError.js";
 
 // Length of random prefix for unique filenames (6 hex chars = 16M combinations)
 const FILENAME_RANDOM_LENGTH = 6;
@@ -343,7 +344,7 @@ export async function POST(request: NextRequest) {
           totalSize: extractedFiles.reduce((sum, f) => sum + f.size, 0),
         });
       } catch (extractError) {
-        log.error("[Download] Failed to extract zip file:", extractError);
+        log.error("[Download] Failed to extract zip file:", formatApiError(extractError));
         // Fall back to returning the zip file itself
         return NextResponse.json({
           success: true,
@@ -390,7 +391,7 @@ export async function POST(request: NextRequest) {
     });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : "Unknown error";
-    log.error("[Download] Failed to download file:", error);
+    log.error("[Download] Failed to download file:", formatApiError(error));
     return NextResponse.json({ error: errorMessage }, { status: 500 });
   }
 }

--- a/src/app/api/makerworld/sync/route.ts
+++ b/src/app/api/makerworld/sync/route.ts
@@ -4,6 +4,7 @@ import { makerWorldLicenseToPubman, makerWorldCategoryIdToPubman } from "../make
 import { PLATFORM_IDS, PUBLISHED_STATUS } from "../../../lib/constants/platforms";
 import log from "electron-log/renderer";
 import path from "path";
+import { formatApiError } from "../../../lib/logApiError.js";
 
 interface MakerWorldDesignData {
   id: number;           // MakerWorld internal ID (used for drafts and API calls)
@@ -250,7 +251,7 @@ export async function POST(request: NextRequest) {
   });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : "Unknown error";
-    log.error("[Sync] Failed to sync MakerWorld design:", error);
+    log.error("[Sync] Failed to sync MakerWorld design:", formatApiError(error));
     return NextResponse.json({ error: errorMessage }, { status: 500 });
   }
 }
@@ -433,7 +434,7 @@ export async function GET(request: NextRequest) {
     });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : "Unknown error";
-    log.error("[Sync] Failed to get sync status:", error);
+    log.error("[Sync] Failed to get sync status:", formatApiError(error));
     return NextResponse.json({ error: errorMessage }, { status: 500 });
   }
 }

--- a/src/app/api/makerworld/user/route.js
+++ b/src/app/api/makerworld/user/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { MakerWorldAPI, MakerWorldAPIError } from '../makerworld-lib';
 import log from "electron-log/renderer";
+import { formatApiError } from '../../../lib/logApiError.js';
 
 export async function GET(request) {
   try {
@@ -14,7 +15,7 @@ export async function GET(request) {
 
     return NextResponse.json(userData, { status: 200 });
   } catch (error) {
-    log.error('Failed to get MakerWorld user info:', error);
+    log.error('Failed to get MakerWorld user info:', formatApiError(error));
 
     // Check if the error is due to an invalid token
     if (error instanceof MakerWorldAPIError && error.statusCode === 401) {

--- a/src/app/api/printables/auth/callback/save/route.js
+++ b/src/app/api/printables/auth/callback/save/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import {getDatabase} from "../../../../../lib/betterSqlite3";
 import log from "electron-log/renderer";
+import { formatApiError } from '../../../../../lib/logApiError.js';
 
 export async function GET(request) {
   try {
@@ -52,7 +53,7 @@ export async function GET(request) {
       accessToken,
     });
   } catch (error) {
-    log.error('OAuth callback error:', error);
+    log.error('OAuth callback error:', formatApiError(error));
     return NextResponse.json({ error: 'Authentication failed' }, { status: 500 });
   }
 }

--- a/src/app/api/printables/auth/token/route.js
+++ b/src/app/api/printables/auth/token/route.js
@@ -1,6 +1,7 @@
 import {getDatabase} from "../../../../lib/betterSqlite3";
 import {NextResponse} from "next/server";
 import log from "electron-log/renderer";
+import { formatApiError } from '../../../../lib/logApiError.js';
 
 export async function GET() {
   try {
@@ -13,7 +14,7 @@ export async function GET() {
       return NextResponse.json({ token: null });
     }
   } catch (error) {
-    log.error('Failed to get token:', error);
+    log.error('Failed to get token:', formatApiError(error));
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }
@@ -30,7 +31,7 @@ export async function POST(request) {
     await db.prepare('INSERT OR REPLACE INTO auth_tokens (provider, token) VALUES (?, ?)').run('printables', token);
     return NextResponse.json({ success: true });
   } catch (error) {
-    log.error('Failed to save token:', error);
+    log.error('Failed to save token:', formatApiError(error));
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }
@@ -41,7 +42,7 @@ export async function DELETE() {
     await db.prepare('DELETE FROM auth_tokens WHERE provider = ?').run('printables');
     return NextResponse.json({ success: true });
   } catch (error) {
-    log.error('Failed to delete token:', error);
+    log.error('Failed to delete token:', formatApiError(error));
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/src/app/api/printables/file/upload/route.js
+++ b/src/app/api/printables/file/upload/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { PrintablesAPI } from '../../printables-lib';
 import log from "electron-log/renderer";
+import { formatApiError } from '../../../../lib/logApiError.js';
 
 export async function POST(request) {
   try {
@@ -24,7 +25,7 @@ export async function POST(request) {
 
     return NextResponse.json({"success": true, file: result}, { status: 201 });
   } catch (error) {
-    log.error('Failed to upload file to Printables:', error);
+    log.error('Failed to upload file to Printables:', formatApiError(error));
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/src/app/api/printables/model/route.js
+++ b/src/app/api/printables/model/route.js
@@ -4,6 +4,7 @@ import log from "electron-log/renderer";
 import path from "path";
 import fs from "fs";
 import {getDatabase} from "../../../lib/betterSqlite3";
+import { formatApiError } from '../../../lib/logApiError.js';
 
 const PRINTABLES_PLATFORM_ID = 4;
 const PUBLISHED_STATUS_DRAFT = 1;
@@ -54,7 +55,7 @@ export async function POST(request) {
             fileIds.push(uploadResult.id)
           }
         } catch (error) {
-          log.error(`Failed to upload file ${asset.file_name}:`, error);
+          log.error(`Failed to upload file ${asset.file_name}:`, formatApiError(error));
           hasFileErrors = true;
           fileResults.push({
             action: 'upload',
@@ -216,7 +217,7 @@ export async function POST(request) {
       designPlatform: designPlatform
     }, { status: designId ? 200 : 201 });
   } catch (error) {
-    log.error('Failed to create Printables model:', error);
+    log.error('Failed to create Printables model:', formatApiError(error));
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 }

--- a/src/app/api/printables/printables-lib.js
+++ b/src/app/api/printables/printables-lib.js
@@ -1018,7 +1018,18 @@ export class PrintablesAPI {
     });
 
     if (!response.ok) {
-      throw new Error(`Printables API error: ${url} ${JSON.stringify(variables)} ${response.status} ${response.statusText}`);
+      // Capture the response body before throwing - it's the actual reason the GraphQL
+      // call was rejected (e.g. a specific field validation error), and was previously
+      // being dropped entirely, leaving every Printables failure looking identical.
+      const responseBody = await response.text();
+      const error = new Error(`Printables API error: ${url} ${response.status} ${response.statusText}`);
+      error.url = url;
+      error.method = 'POST';
+      error.requestBody = variables;
+      error.responseStatus = response.status;
+      error.responseStatusText = response.statusText;
+      error.responseBody = responseBody;
+      throw error;
     }
 
     return response.json();

--- a/src/app/api/printables/user/route.js
+++ b/src/app/api/printables/user/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { PrintablesAPI } from '../printables-lib';
 import log from "electron-log/renderer";
+import { formatApiError } from '../../../lib/logApiError.js';
 
 export async function GET(request) {
   try {
@@ -14,7 +15,7 @@ export async function GET(request) {
 
     return NextResponse.json(userData, { status: 200 });
   } catch (error) {
-    log.error('Failed to get Printables user info:', error);
+    log.error('Failed to get Printables user info:', formatApiError(error));
 
     // Check if the error is due to an invalid token
     if (error.message && error.message.includes('401')) {

--- a/src/app/api/thingiverse/[thingId]/files/route.js
+++ b/src/app/api/thingiverse/[thingId]/files/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ThingiverseAPI } from '../../thingiverse-lib';
 import log from "electron-log/renderer";
+import { formatApiError } from '../../../../lib/logApiError.js';
 
 export async function GET(request, { params }) {
   try {
@@ -15,7 +16,7 @@ export async function GET(request, { params }) {
 
     return NextResponse.json(files, { status: 200 });
   } catch (error) {
-    log.error('Failed to get Thingiverse files:', error);
+    log.error('Failed to get Thingiverse files:', formatApiError(error));
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }
@@ -43,7 +44,7 @@ export async function POST(request, { params }) {
 
     return NextResponse.json(result, { status: 201 });
   } catch (error) {
-    log.error('Failed to upload file to Thingiverse:', error);
+    log.error('Failed to upload file to Thingiverse:', formatApiError(error));
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/src/app/api/thingiverse/[thingId]/files/thingId-files.test.js
+++ b/src/app/api/thingiverse/[thingId]/files/thingId-files.test.js
@@ -1,6 +1,7 @@
 import { GET, POST } from './route';
 import { ThingiverseAPI } from '../../thingiverse-lib';
 import log from 'electron-log/renderer';
+import { formatApiError } from '../../../../lib/logApiError.js';
 
 jest.mock('../../thingiverse-lib', () => ({
   ThingiverseAPI: jest.fn().mockImplementation(() => ({
@@ -48,7 +49,8 @@ describe('GET /api/thingiverse/[thingId]/files', () => {
   });
 
   it('should return 500 on internal server error', async () => {
-    const mockGetFilesForThing = jest.fn().mockRejectedValue(new Error('Internal error'));
+    const mockError = new Error('Internal error');
+    const mockGetFilesForThing = jest.fn().mockRejectedValue(mockError);
     ThingiverseAPI.mockImplementation(() => ({ getFilesForThing: mockGetFilesForThing }));
 
     const request = {
@@ -63,7 +65,7 @@ describe('GET /api/thingiverse/[thingId]/files', () => {
     expect(await response.json()).toEqual({ error: 'Internal server error' });
     expect(log.error).toHaveBeenCalledWith(
       'Failed to get Thingiverse files:',
-      expect.any(Error)
+      formatApiError(mockError)
     );
   });
 });
@@ -138,7 +140,8 @@ describe('POST /api/thingiverse/[thingId]/files', () => {
   });
 
   it('should return 500 on internal server error', async () => {
-    const mockUploadFile = jest.fn().mockRejectedValue(new Error('Internal error'));
+    const mockError = new Error('Internal error');
+    const mockUploadFile = jest.fn().mockRejectedValue(mockError);
     ThingiverseAPI.mockImplementation(() => ({ uploadFile: mockUploadFile }));
 
     const mockFile = {
@@ -162,7 +165,7 @@ describe('POST /api/thingiverse/[thingId]/files', () => {
     expect(await response.json()).toEqual({ error: 'Internal server error' });
     expect(log.error).toHaveBeenCalledWith(
       'Failed to upload file to Thingiverse:',
-      expect.any(Error)
+      formatApiError(mockError)
     );
   });
 });

--- a/src/app/api/thingiverse/[thingId]/publish/route.js
+++ b/src/app/api/thingiverse/[thingId]/publish/route.js
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ThingiverseAPI } from '../../thingiverse-lib';
 import {getDatabase} from "../../../../lib/betterSqlite3";
 import log from "electron-log/renderer";
+import { formatApiError } from '../../../../lib/logApiError.js';
 
 export async function POST(request, { params }) {
   try {
@@ -77,7 +78,7 @@ export async function POST(request, { params }) {
       }
     }, { status: 200 });
   } catch (error) {
-    log.error('Failed to publish Thingiverse thing:', error);
+    log.error('Failed to publish Thingiverse thing:', formatApiError(error));
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/src/app/api/thingiverse/[thingId]/publish/thingId-publish.test.js
+++ b/src/app/api/thingiverse/[thingId]/publish/thingId-publish.test.js
@@ -2,6 +2,7 @@ import {POST} from './route';
 import {ThingiverseAPI} from '../../thingiverse-lib';
 import {getDatabase} from "../../../../lib/betterSqlite3";
 import log from 'electron-log/renderer';
+import { formatApiError } from '../../../../lib/logApiError.js';
 
 // Mock dependencies
 jest.mock('../../thingiverse-lib');
@@ -153,6 +154,6 @@ describe('POST /api/thingiverse/[thingId]/publish', () => {
 
     expect(response.status).toBe(500);
     expect(await response.json()).toEqual({error: 'Internal server error'});
-    expect(log.error).toHaveBeenCalledWith('Failed to publish Thingiverse thing:', mockError);
+    expect(log.error).toHaveBeenCalledWith('Failed to publish Thingiverse thing:', formatApiError(mockError));
   });
 });

--- a/src/app/api/thingiverse/[thingId]/route.js
+++ b/src/app/api/thingiverse/[thingId]/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ThingiverseAPI } from '../thingiverse-lib';
 import log from "electron-log/renderer";
+import { formatApiError } from '../../../lib/logApiError.js';
 
 export async function GET(request, { params }) {
   try {
@@ -15,7 +16,7 @@ export async function GET(request, { params }) {
 
     return NextResponse.json(thing, { status: 200 });
   } catch (error) {
-    log.error('Failed to get Thingiverse thing:', error);
+    log.error('Failed to get Thingiverse thing:', formatApiError(error));
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }
@@ -34,7 +35,7 @@ export async function PATCH(request, { params }) {
     const updatedThing = await api.updateThing(thingId, updates);
     return NextResponse.json(updatedThing, { status: 200 });
   }  catch (error) {
-    log.error('Failed to update Thingiverse thing:', error);
+    log.error('Failed to update Thingiverse thing:', formatApiError(error));
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/src/app/api/thingiverse/[thingId]/thingId-PATCH.test.js
+++ b/src/app/api/thingiverse/[thingId]/thingId-PATCH.test.js
@@ -2,6 +2,7 @@
 import { PATCH } from './route';  // Fix the import path
 import { ThingiverseAPI } from '../thingiverse-lib';
 import log from 'electron-log/renderer';
+import { formatApiError } from '../../../lib/logApiError.js';
 
 jest.mock('../thingiverse-lib', () => ({
   ThingiverseAPI: jest.fn().mockImplementation(() => ({
@@ -43,7 +44,8 @@ describe('PATCH /api/thingiverse/[thingId]', () => {
   });
 
   it('should return 500 on internal server error', async () => {
-    const mockUpdateThing = jest.fn().mockRejectedValue(new Error('Internal error'));
+    const mockError = new Error('Internal error');
+    const mockUpdateThing = jest.fn().mockRejectedValue(mockError);
     ThingiverseAPI.mockImplementation(() => ({ updateThing: mockUpdateThing }));
 
     const request = {
@@ -58,7 +60,7 @@ describe('PATCH /api/thingiverse/[thingId]', () => {
     expect(await response.json()).toEqual({ error: 'Internal server error' });
     expect(log.error).toHaveBeenCalledWith(
       'Failed to update Thingiverse thing:',
-      expect.any(Error)
+      formatApiError(mockError)
     );
   });
 });

--- a/src/app/api/thingiverse/auth/callback/save/route.js
+++ b/src/app/api/thingiverse/auth/callback/save/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import {getDatabase} from "../../../../../lib/betterSqlite3";
 import log from "electron-log/renderer";
+import { formatApiError } from '../../../../../lib/logApiError.js';
 
 const THINGIVERSE_CLIENT_ID = process.env.THINGIVERSE_CLIENT_ID;
 
@@ -62,7 +63,7 @@ export async function GET(request) {
       }
     );
   } catch (error) {
-    log.error('OAuth callback error:', error);
+    log.error('OAuth callback error:', formatApiError(error));
     return NextResponse.json({ error: 'Authentication failed' }, { status: 500 });
   }
 }

--- a/src/app/api/thingiverse/auth/refresh/route.js
+++ b/src/app/api/thingiverse/auth/refresh/route.js
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getDatabase } from "../../../../lib/betterSqlite3";
 import { ThingiverseAPI } from '../../thingiverse-lib';
 import log from 'electron-log/renderer';
+import { formatApiError } from '../../../../lib/logApiError.js';
 
 export async function POST() {
   try {
@@ -29,7 +30,7 @@ export async function POST() {
       // Token is invalid or expired, need to get a new one
       // Unfortunately, Thingiverse OAuth doesn't support refresh tokens without user interaction
       // We need to tell the client to initiate a new auth flow
-      log.error('Token refresh error:', tokenError);
+      log.error('Token refresh error:', formatApiError(tokenError));
 
       // Delete the invalid token
       await db.prepare('DELETE FROM auth_tokens WHERE provider = ?').run('thingiverse');
@@ -45,7 +46,7 @@ export async function POST() {
       );
     }
   } catch (error) {
-    log.error('Token refresh error:', error);
+    log.error('Token refresh error:', formatApiError(error));
     return NextResponse.json({ error: 'Failed to refresh token' }, { status: 500 });
   }
 }

--- a/src/app/api/thingiverse/auth/token/route.js
+++ b/src/app/api/thingiverse/auth/token/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import {getDatabase} from "../../../../lib/betterSqlite3";
 import log from "electron-log/renderer";
+import { formatApiError } from '../../../../lib/logApiError.js';
 
 export async function GET() {
   try {
@@ -13,7 +14,7 @@ export async function GET() {
       return NextResponse.json({ token: null });
     }
   } catch (error) {
-    log.error('Failed to get token:', error);
+    log.error('Failed to get token:', formatApiError(error));
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }
@@ -24,7 +25,7 @@ export async function DELETE() {
     await db.prepare('DELETE FROM auth_tokens WHERE provider = ?').run('thingiverse');
     return NextResponse.json({ success: true });
   } catch (error) {
-    log.error('Failed to delete token:', error);
+    log.error('Failed to delete token:', formatApiError(error));
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/src/app/api/thingiverse/route.js
+++ b/src/app/api/thingiverse/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ThingiverseAPI } from './thingiverse-lib';
 import log from "electron-log/renderer";
+import { formatApiError } from '../../lib/logApiError.js';
 
 export async function GET(request) {
   try {
@@ -22,7 +23,7 @@ export async function GET(request) {
       return NextResponse.json(userInfo, { status: 200 });
     }
   } catch (error) {
-    log.error('Thingiverse API error:', error);
+    log.error('Thingiverse API error:', formatApiError(error));
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/src/app/api/thingiverse/things/route.js
+++ b/src/app/api/thingiverse/things/route.js
@@ -4,6 +4,7 @@ import {getDatabase} from "../../../lib/betterSqlite3";
 import fs from "fs";
 import path from "path";
 import log from "electron-log/renderer";
+import { formatApiError } from '../../../lib/logApiError.js';
 
 // Thingiverse platform ID is 3 according to the schema
 const THINGIVERSE_PLATFORM_ID = 3;
@@ -26,7 +27,7 @@ export async function GET(request) {
     const things = await api.getThingsByUsername(username);
     return NextResponse.json(things, { status: 200 });
   } catch (error) {
-    log.error('Failed to get Thingiverse things:', error);
+    log.error('Failed to get Thingiverse things:', formatApiError(error));
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }
@@ -96,7 +97,7 @@ export async function POST(request) {
             result: deleteResult
           });
         } catch (error) {
-          log.error(`Failed to delete image ${image.id} ${image.name}:`, error);
+          log.error(`Failed to delete image ${image.id} ${image.name}:`, formatApiError(error));
           hasFileErrors = true;
           fileResults.push({
             action: 'delete',
@@ -119,7 +120,7 @@ export async function POST(request) {
             result: deleteResult
           });
         } catch (error) {
-          log.error(`Failed to delete file ${file.id} ${file.name}:`, error);
+          log.error(`Failed to delete file ${file.id} ${file.name}:`, formatApiError(error));
           hasFileErrors = true;
           fileResults.push({
             action: 'delete',
@@ -148,7 +149,7 @@ export async function POST(request) {
             result: uploadResult
           });
         } catch (error) {
-          log.error(`Failed to upload file ${asset.file_name}:`, error);
+          log.error(`Failed to upload file ${asset.file_name}:`, formatApiError(error));
           hasFileErrors = true;
           fileResults.push({
             action: 'upload',
@@ -189,7 +190,7 @@ export async function POST(request) {
       designPlatform: designPlatform
     }, { status: thingId ? 200 : 201 });
   } catch (error) {
-    log.error('Failed to create Thingiverse thing:', error);
+    log.error('Failed to create Thingiverse thing:', formatApiError(error));
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/src/app/api/thingiverse/tv-GET.test.js
+++ b/src/app/api/thingiverse/tv-GET.test.js
@@ -1,6 +1,7 @@
 import { GET } from './route';
 import { ThingiverseAPI } from './thingiverse-lib';
 import log from 'electron-log/renderer';
+import { formatApiError } from '../../lib/logApiError.js';
 
 jest.mock('./thingiverse-lib', () => ({
   ThingiverseAPI: jest.fn().mockImplementation(() => ({
@@ -73,7 +74,8 @@ describe('GET /api/thingiverse', () => {
   });
 
   it('should return 500 on internal server error', async () => {
-    const mockGetUserInfo = jest.fn().mockRejectedValue(new Error('Internal error'));
+    const mockError = new Error('Internal error');
+    const mockGetUserInfo = jest.fn().mockRejectedValue(mockError);
     ThingiverseAPI.mockImplementation(() => ({ getUserInfo: mockGetUserInfo }));
 
     const request = {
@@ -93,7 +95,7 @@ describe('GET /api/thingiverse', () => {
     expect(await response.json()).toEqual({ error: 'Internal server error' });
     expect(log.error).toHaveBeenCalledWith(
       'Thingiverse API error:',
-      expect.any(Error)
+      formatApiError(mockError)
     );
   });
 });

--- a/src/app/api/thingiverse/user/route.js
+++ b/src/app/api/thingiverse/user/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ThingiverseAPI } from '../thingiverse-lib';
 import log from "electron-log/renderer";
+import { formatApiError } from '../../../lib/logApiError.js';
 
 export async function GET(request) {
   try {
@@ -14,7 +15,7 @@ export async function GET(request) {
 
     return NextResponse.json(userData, { status: 200 });
   } catch (error) {
-    log.error('Failed to get Thingiverse user info:', error);
+    log.error('Failed to get Thingiverse user info:', formatApiError(error));
 
     // Check if the error is due to an invalid token
     if (error.message && error.message.includes('401')) {

--- a/src/app/components/dashboard/makerworld-sync.tsx
+++ b/src/app/components/dashboard/makerworld-sync.tsx
@@ -17,6 +17,7 @@ import {
   licensesAreEqual,
 } from "../../lib/makerworld-client";
 import log from "electron-log/renderer";
+import { formatApiError } from "../../lib/logApiError.js";
 import { RefreshCw, Check, Download, AlertCircle, ExternalLink, GitMerge, ChevronDown, Settings2 } from "lucide-react";
 import {
   DraftSummary,
@@ -214,7 +215,7 @@ export function MakerWorldSync({
       }));
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Failed to fetch designs";
-      log.error("[MakerWorld Sync] Error fetching designs:", error);
+      log.error("[MakerWorld Sync] Error fetching designs:", formatApiError(error));
       setState((prev) => ({
         ...prev,
         isFetching: false,
@@ -326,7 +327,7 @@ export function MakerWorldSync({
           }, 500);
         }
       } catch (error) {
-        log.error("[MakerWorld Sync] Failed to open captcha window:", error);
+        log.error("[MakerWorld Sync] Failed to open captcha window:", formatApiError(error));
         // Fallback to external browser with design page
         const url = designId
           ? `https://makerworld.com/en/models/${designId}`
@@ -1090,7 +1091,7 @@ export function MakerWorldSync({
           break;
         }
 
-        log.error(`[MakerWorld Sync] Failed to sync ${design.title}:`, error);
+        log.error(`[MakerWorld Sync] Failed to sync ${design.title}:`, formatApiError(error));
         setState((prev) => ({
           ...prev,
           failed: [...prev.failed, { id: design.id, name: design.title, error: errorMessage }],
@@ -1192,7 +1193,7 @@ export function MakerWorldSync({
       };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Unknown error";
-      log.error(`[MakerWorld Sync] Download failed for ${fileName}:`, error);
+      log.error(`[MakerWorld Sync] Download failed for ${fileName}:`, formatApiError(error));
       return { success: false, error: errorMessage };
     }
   };

--- a/src/app/lib/logApiError.js
+++ b/src/app/lib/logApiError.js
@@ -1,0 +1,37 @@
+// PubMan's platform API clients (thingiverse-lib.js, printables-lib.js, makerworld-lib.js,
+// makerworld-client.ts) throw errors carrying rich diagnostic detail - either embedded in
+// `.message` as a string, or as separate own-properties (url, method, requestBody,
+// responseStatus, responseStatusText, responseBody, validationIssues) on custom error
+// classes like MakerWorldAPIError. That detail was frequently being captured but never
+// reaching the actual log output, since passing an Error object straight to a logger
+// typically only surfaces `.message`/`.stack`, not arbitrary custom properties.
+//
+// formatApiError renders whichever of these is present, so `log.error(context,
+// formatApiError(error))` always surfaces the full failure detail regardless of which
+// platform/error shape it came from.
+
+const DIAGNOSTIC_KEYS = [
+  'url',
+  'method',
+  'requestBody',
+  'responseStatus',
+  'responseStatusText',
+  'responseBody',
+  'validationIssues',
+];
+
+export function formatApiError(error) {
+  if (!(error instanceof Error)) {
+    if (error === undefined || error === null) return String(error);
+    return typeof error === 'string' ? error : JSON.stringify(error);
+  }
+
+  const parts = [error.message];
+  for (const key of DIAGNOSTIC_KEYS) {
+    const value = error[key];
+    if (value === undefined || value === null) continue;
+    const rendered = typeof value === 'string' ? value : JSON.stringify(value);
+    parts.push(`${key}=${rendered}`);
+  }
+  return parts.join(' | ');
+}

--- a/src/app/lib/logApiError.test.js
+++ b/src/app/lib/logApiError.test.js
@@ -1,0 +1,62 @@
+import { formatApiError } from './logApiError';
+
+describe('formatApiError', () => {
+  it('renders a plain Error as just its message', () => {
+    expect(formatApiError(new Error('boom'))).toBe('boom');
+  });
+
+  it('surfaces diagnostic properties attached to an Error', () => {
+    const error = new Error('Printables API error: https://api.printables.com/graphql/ 401 Unauthorized');
+    error.url = 'https://api.printables.com/graphql/';
+    error.method = 'POST';
+    error.requestBody = { id: '1783880', loadPurchase: false };
+    error.responseStatus = 401;
+    error.responseStatusText = 'Unauthorized';
+    error.responseBody = '{"errors":[{"message":"tag contains invalid characters"}]}';
+
+    const formatted = formatApiError(error);
+    expect(formatted).toContain('Printables API error');
+    expect(formatted).toContain('url=https://api.printables.com/graphql/');
+    expect(formatted).toContain('method=POST');
+    expect(formatted).toContain('requestBody={"id":"1783880","loadPurchase":false}');
+    expect(formatted).toContain('responseStatus=401');
+    expect(formatted).toContain('responseStatusText=Unauthorized');
+    expect(formatted).toContain('responseBody={"errors":[{"message":"tag contains invalid characters"}]}');
+  });
+
+  it('omits keys that are absent, without producing "undefined"/"null" noise', () => {
+    const error = new Error('MakerWorld API error');
+    error.responseStatus = 500;
+    const formatted = formatApiError(error);
+    expect(formatted).toBe('MakerWorld API error | responseStatus=500');
+    expect(formatted).not.toMatch(/undefined|null/);
+  });
+
+  it('handles a MakerWorldAPIError-shaped object (constructed via Object.assign, not a subclass)', () => {
+    const error = Object.assign(new Error('MakerWorld API error'), {
+      name: 'MakerWorldAPIError',
+      url: 'https://api.bambulab.com/v1/design-service/my/draft',
+      method: 'POST',
+      responseStatus: 400,
+      responseStatusText: 'Bad Request',
+      responseBody: '{"code":-1,"error":"validation failed"}',
+      validationIssues: [{ path: 'tags', message: 'invalid character' }],
+    });
+
+    const formatted = formatApiError(error);
+    expect(formatted).toContain('validationIssues=[{"path":"tags","message":"invalid character"}]');
+  });
+
+  it('JSON-stringifies non-Error values rather than relying on default serialization', () => {
+    expect(formatApiError({ status: 500, body: 'oops' })).toBe('{"status":500,"body":"oops"}');
+  });
+
+  it('passes strings through unchanged', () => {
+    expect(formatApiError('plain string error')).toBe('plain string error');
+  });
+
+  it('stringifies null/undefined without throwing', () => {
+    expect(formatApiError(null)).toBe('null');
+    expect(formatApiError(undefined)).toBe('undefined');
+  });
+});

--- a/src/app/lib/makerworld-client.ts
+++ b/src/app/lib/makerworld-client.ts
@@ -5,6 +5,7 @@
 
 import { z } from 'zod';
 import log from 'electron-log/renderer';
+import { formatApiError } from './logApiError.js';
 
 // Window.electron types are defined in MakerWorldAuthContext.tsx
 
@@ -291,19 +292,14 @@ export class MakerWorldClientAPI {
         responseStatusText: response.statusText,
         responseBody: response.body,
       });
-      log.error(`[MakerWorld API] Request failed:`, {
-        url,
-        method,
-        status: response.status,
-        statusText: response.statusText,
-      });
+      log.error(`[MakerWorld API] Request failed:`, formatApiError(error));
       throw error;
     }
 
     try {
       return response.body ? JSON.parse(response.body) : null;
     } catch (parseError) {
-      log.error(`[MakerWorld API] Failed to parse response as JSON:`, parseError);
+      log.error(`[MakerWorld API] Failed to parse response as JSON:`, formatApiError(parseError));
       throw new MakerWorldClientAPIError({
         message: 'Failed to parse response',
         url,
@@ -451,7 +447,7 @@ export class MakerWorldClientAPI {
       log.info(`[MakerWorld S3] <<< Upload successful: ${resultUrl}`);
       return { url: resultUrl };
     } catch (error) {
-      log.error(`[MakerWorld S3] <<< Upload failed:`, error);
+      log.error(`[MakerWorld S3] <<< Upload failed:`, formatApiError(error));
       throw error;
     }
   }
@@ -569,7 +565,7 @@ export class MakerWorldClientAPI {
           log.warn('[MakerWorld API] Could not find designs in __NEXT_DATA__, pageProps keys:', Object.keys(pageProps).join(', '));
         }
       } catch (e) {
-        log.error('[MakerWorld API] Failed to parse __NEXT_DATA__:', e);
+        log.error('[MakerWorld API] Failed to parse __NEXT_DATA__:', formatApiError(e));
       }
     }
 


### PR DESCRIPTION
## Summary
Every platform integration's failing HTTP call already captures rich diagnostic detail — a status code and response body embedded in `thingiverse-lib.js`'s error messages, or separate `url`/`method`/`requestBody`/`responseStatus`/`responseBody`/`validationIssues` properties on `MakerWorldAPIError` and `MakerWorldClientAPIError` — but ~65 `log.error` call sites across Thingiverse/Printables/MakerWorld only ever logged the bare caught error, which for structured error classes surfaces just `.message` (a generic string) and silently drops every other property. In practice this meant every failed publish attempt looked identical in `main.log` regardless of the actual cause — which cost real debugging time chasing the wrong theories before the actual root cause (an invalid character in a tag) turned up.

- Added `src/app/lib/logApiError.js` exporting `formatApiError(error)`, which renders the message plus any of those diagnostic properties that are present, for any of this codebase's error shapes.
- `printables-lib.js`'s `graphql()` didn't even capture the response body on a failed request — fixed to attach `responseStatus`/`responseBody`/etc. like the other two platforms' clients already do.
- Wired `formatApiError` into every catch block across all three platforms' routes, lib files, and (for MakerWorld) the client-side sync UI — including one case in `makerworld-client.ts` that was already constructing a fully-detailed error but then logging a hand-built object that specifically omitted the response body.
- Updated the handful of Thingiverse tests that asserted on the raw `Error` object being logged, to assert on the new formatted string instead.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx eslint` on every touched source file — clean
- [x] `npx jest` — all 8 suites / 33 tests pass, including a new `logApiError.test.js` (7 tests) covering: plain Error passthrough, diagnostic-property rendering, omitting absent keys without `undefined`/`null` noise, a `MakerWorldAPIError`-shaped object, non-Error value JSON-stringification, string passthrough, and null/undefined handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)