### PR TITLE
Add print profiles: local 3MF extraction + MakerWorld publishing

### DIFF
--- a/db/migrations-007.txt
+++ b/db/migrations-007.txt
@@ -1,0 +1,26 @@
+-- Migration 007: Add print_profile table for print settings extracted from 3MF slicer projects
+CREATE TABLE IF NOT EXISTS print_profile (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    design_asset_id INTEGER NOT NULL UNIQUE,
+    printer_model TEXT,
+    printer_settings_name TEXT,
+    nozzle_diameter REAL,
+    bed_type TEXT,
+    layer_height REAL,
+    first_layer_height REAL,
+    wall_loops INTEGER,
+    infill_density REAL,
+    infill_pattern TEXT,
+    supports_enabled INTEGER NOT NULL DEFAULT 0,
+    support_type TEXT,
+    print_settings_name TEXT,
+    filament_types TEXT NOT NULL DEFAULT '[]',
+    filament_colors TEXT NOT NULL DEFAULT '[]',
+    filament_names TEXT NOT NULL DEFAULT '[]',
+    plate_count INTEGER,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(design_asset_id) REFERENCES design_asset(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_print_profile_design_asset_id ON print_profile(design_asset_id);

--- a/db/migrations-008.txt
+++ b/db/migrations-008.txt
@@ -1,0 +1,3 @@
+-- Migration 008: Track the MakerWorld draft/profile id each 3MF print profile was uploaded as,
+-- so re-publishing updates that MakerWorld instance instead of creating a duplicate.
+ALTER TABLE print_profile ADD COLUMN makerworld_profile_id TEXT;

--- a/next.config.ts
+++ b/next.config.ts
@@ -14,6 +14,15 @@ const nextConfig: NextConfig = {
       bodySizeLimit: '50mb'
     },
   },
+  // Server-side code (e.g. src/app/lib/makerworldServer.js) imports 'electron' directly so it
+  // can reach session/cookie APIs without going through the renderer's IPC bridge. Without this,
+  // webpack bundles node_modules/electron/index.js's dev-time "find the electron binary" shim
+  // straight into the compiled route - which throws ("Electron failed to install correctly")
+  // because that shim only makes sense invoked from a plain `electron .` launch, not from inside
+  // a bundled server chunk. Marking it external leaves a real `require("electron")`/
+  // `import("electron")` in the output for Node's module resolution to handle at actual runtime,
+  // which inside the packaged app is intercepted natively by Electron itself.
+  serverExternalPackages: ["electron"],
 };
 
 export default nextConfig;

--- a/src/app/actions/file.ts
+++ b/src/app/actions/file.ts
@@ -71,3 +71,18 @@ export async function removeFile(designID: string, assetID: string) {
     throw new Error('Failed to remove file');
   }
 }
+
+export async function generatePrintProfile(designID: string, assetID: string) {
+  try {
+    const response = await fetch(`${API_URL}/api/design/${designID}/asset/${assetID}/print-profile`, {
+      method: "POST",
+    });
+    if (!response.ok) {
+      throw new Error('Failed to generate print profile');
+    }
+    return await response.json();
+  } catch (error) {
+    log.error('Error generating print profile:', error);
+    throw new Error('Failed to generate print profile');
+  }
+}

--- a/src/app/api/design/[designID]/asset/[assetID]/print-profile/makerworld/route.js
+++ b/src/app/api/design/[designID]/asset/[assetID]/print-profile/makerworld/route.js
@@ -1,0 +1,146 @@
+import { NextResponse } from 'next/server';
+import fs from 'fs/promises';
+import path from 'path';
+import { getDatabase } from '../../../../../../../lib/betterSqlite3';
+import { formatPrintProfileRow, setMakerWorldProfileId } from '../../../../../../../lib/printProfile';
+import {
+  getMakerWorldS3Config,
+  uploadFileToMakerWorldS3,
+  createMakerWorldDraft,
+  updateMakerWorldDraft,
+  submitMakerWorldDraft,
+} from '../../../../../../../lib/makerworldServer';
+import { AddPrintProfileRequestSchema, makerWorldPrinterDevModels, MakerWorldAPI } from '../../../../../../makerworld/makerworld-lib';
+import log from 'electron-log/node';
+
+const MAKERWORLD_PLATFORM_ID = 5;
+const PUBLISHED_STATUS_PUBLISHED = 2;
+
+// POST /api/design/[designID]/asset/[assetID]/print-profile/makerworld
+// Creates (or updates) a MakerWorld print profile for a .3mf asset, end to end, entirely
+// server-side: reads the file and the chosen photo off disk, uploads both to MakerWorld's S3,
+// then creates and submits the profile draft. Runs over plain HTTP with no dependency on the
+// Electron renderer/preload context, so it works whether PubMan is driven from the packaged
+// app window or any other HTTP client pointed at the same server.
+export async function POST(request, context) {
+  const { designID, assetID } = await context.params;
+  const db = getDatabase();
+
+  const body = await request.json();
+  const { title, photo_asset_id: photoAssetId } = body;
+  if (!title || typeof title !== 'string' || !title.trim()) {
+    return NextResponse.json({ error: 'title is required' }, { status: 400 });
+  }
+  if (!photoAssetId) {
+    return NextResponse.json({ error: 'photo_asset_id is required' }, { status: 400 });
+  }
+
+  const asset = db.prepare(`
+    SELECT id, file_name, file_ext, file_path FROM design_asset
+    WHERE id = ? AND design_id = ? AND deleted_at IS NULL
+  `).get(assetID, designID);
+  if (!asset) {
+    return NextResponse.json({ error: 'Asset not found' }, { status: 404 });
+  }
+  if (asset.file_ext.toLowerCase() !== '3mf') {
+    return NextResponse.json({ error: 'Only .3mf assets can become a MakerWorld print profile' }, { status: 400 });
+  }
+
+  const photo = db.prepare(`
+    SELECT id, file_name, file_ext, file_path FROM design_asset
+    WHERE id = ? AND design_id = ? AND deleted_at IS NULL
+  `).get(photoAssetId, designID);
+  if (!photo) {
+    return NextResponse.json({ error: 'Photo asset not found' }, { status: 404 });
+  }
+
+  const mwPlatform = db.prepare(`
+    SELECT platform_design_id, published_status FROM design_platform
+    WHERE design_id = ? AND platform_id = ? AND deleted_at IS NULL
+  `).get(designID, MAKERWORLD_PLATFORM_ID);
+  if (!mwPlatform?.platform_design_id || mwPlatform.published_status !== PUBLISHED_STATUS_PUBLISHED) {
+    return NextResponse.json({ error: 'Design must be published to MakerWorld before adding a print profile' }, { status: 400 });
+  }
+
+  const profileRow = db.prepare('SELECT * FROM print_profile WHERE design_asset_id = ?').get(asset.id);
+  const profile = formatPrintProfileRow(profileRow);
+
+  const appDataPath = process.env.NEXT_PUBLIC_APP_DATA_PATH || path.resolve('appdata');
+
+  // api.bambulab.com's user-info endpoint isn't behind the same Cloudflare protection as
+  // makerworld.com's draft endpoints, so the older plain-token MakerWorldAPI client (also used
+  // by /api/makerworld/user) works fine for this one call - no need for the session-cookie path.
+  const tokenRow = db.prepare(`
+    SELECT token FROM auth_tokens WHERE provider = 'makerworld' ORDER BY updated_at DESC, created_at DESC
+  `).get();
+  if (!tokenRow?.token) {
+    return NextResponse.json({ error: 'Not authenticated to MakerWorld' }, { status: 401 });
+  }
+
+  try {
+    const legacyApi = new MakerWorldAPI(tokenRow.token);
+    const [userInfo, s3Config] = await Promise.all([legacyApi.getUserInfo(), getMakerWorldS3Config()]);
+
+    const [modelBuffer, photoBuffer] = await Promise.all([
+      fs.readFile(path.join(appDataPath, asset.file_path)),
+      fs.readFile(path.join(appDataPath, photo.file_path)),
+    ]);
+
+    const [modelUpload, photoUpload] = await Promise.all([
+      uploadFileToMakerWorldS3(asset.file_name, modelBuffer, userInfo.uid, s3Config),
+      uploadFileToMakerWorldS3(photo.file_name, photoBuffer, userInfo.uid, s3Config),
+    ]);
+
+    const printerModel = profile?.printer_model || '';
+    const knownPrinter = makerWorldPrinterDevModels[printerModel];
+    const existingProfileId = profile?.makerworld_profile_id ? Number(profile.makerworld_profile_id) : 0;
+
+    const payload = AddPrintProfileRequestSchema.parse({
+      parentId: Number(mwPlatform.platform_design_id),
+      profileId: existingProfileId,
+      title: title.trim(),
+      profileTitle: title.trim(),
+      profileCover: photoUpload.url,
+      auxiliaryPictures: [{ name: photo.file_name, url: photoUpload.url }],
+      model3Mf: { name: asset.file_name, url: modelUpload.url, size: modelBuffer.length },
+      printer: {
+        model: printerModel,
+        variant: profile?.nozzle_diameter || 0,
+        settingsId: profile?.printer_settings_name || '',
+      },
+      compatibility: knownPrinter
+        ? { ...knownPrinter, nozzleDiameter: profile?.nozzle_diameter || 0 }
+        : undefined,
+      projectSettings: {
+        layerHeight: profile?.layer_height != null ? String(profile.layer_height) : '',
+        wallLoops: profile?.wall_loops != null ? String(profile.wall_loops) : '',
+        sparseInfillDensity: profile?.infill_density != null ? `${profile.infill_density}%` : '',
+      },
+    });
+
+    let newProfileId = existingProfileId;
+    if (existingProfileId) {
+      log.info(`[MakerWorld] (server) Updating print profile ${existingProfileId} for asset ${asset.id}`);
+      await updateMakerWorldDraft(existingProfileId, payload);
+    } else {
+      log.info(`[MakerWorld] (server) Creating print profile "${title}" for asset ${asset.id}`);
+      const createResult = await createMakerWorldDraft(payload);
+      newProfileId = createResult?.id;
+      if (!newProfileId) {
+        log.error('[MakerWorld] (server) Create draft response had no id:', createResult);
+        return NextResponse.json({ error: "MakerWorld didn't return a profile id" }, { status: 502 });
+      }
+    }
+
+    log.info(`[MakerWorld] (server) Submitting print profile draft ${newProfileId}`);
+    await submitMakerWorldDraft(newProfileId);
+
+    setMakerWorldProfileId(db, asset.id, newProfileId);
+
+    return NextResponse.json({ makerworld_profile_id: String(newProfileId) }, { status: 200 });
+  } catch (error) {
+    log.error(`[MakerWorld] (server) Failed to create print profile for asset ${asset.id}:`, error);
+    const message = error instanceof Error ? error.message : 'Failed to create MakerWorld print profile';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/design/[designID]/asset/[assetID]/print-profile/makerworld/route.js
+++ b/src/app/api/design/[designID]/asset/[assetID]/print-profile/makerworld/route.js
@@ -10,7 +10,7 @@ import {
   updateMakerWorldDraft,
   submitMakerWorldDraft,
 } from '../../../../../../../lib/makerworldServer';
-import { AddPrintProfileRequestSchema, makerWorldPrinterDevModels, MakerWorldAPI } from '../../../../../../makerworld/makerworld-lib';
+import { AddPrintProfileRequestSchema, makerWorldPrinterDevModels, MakerWorldAPI, makerWorldImageFileTypes } from '../../../../../../makerworld/makerworld-lib';
 import log from 'electron-log/node';
 
 const MAKERWORLD_PLATFORM_ID = 5;
@@ -52,6 +52,9 @@ export async function POST(request, context) {
   `).get(photoAssetId, designID);
   if (!photo) {
     return NextResponse.json({ error: 'Photo asset not found' }, { status: 404 });
+  }
+  if (!makerWorldImageFileTypes.includes(photo.file_ext.toLowerCase())) {
+    return NextResponse.json({ error: 'Photo asset must be an image file' }, { status: 400 });
   }
 
   const mwPlatform = db.prepare(`
@@ -130,12 +133,13 @@ export async function POST(request, context) {
         log.error('[MakerWorld] (server) Create draft response had no id:', createResult);
         return NextResponse.json({ error: "MakerWorld didn't return a profile id" }, { status: 502 });
       }
+      // Persist the id immediately, before submit. If submit then fails, a retry finds this
+      // stored id and updates the same draft instead of creating a duplicate profile.
+      setMakerWorldProfileId(db, asset.id, newProfileId);
     }
 
     log.info(`[MakerWorld] (server) Submitting print profile draft ${newProfileId}`);
     await submitMakerWorldDraft(newProfileId);
-
-    setMakerWorldProfileId(db, asset.id, newProfileId);
 
     return NextResponse.json({ makerworld_profile_id: String(newProfileId) }, { status: 200 });
   } catch (error) {

--- a/src/app/api/design/[designID]/asset/[assetID]/print-profile/route.js
+++ b/src/app/api/design/[designID]/asset/[assetID]/print-profile/route.js
@@ -1,0 +1,107 @@
+import { NextResponse } from 'next/server';
+import path from 'path';
+import { getDatabase } from "../../../../../../lib/betterSqlite3";
+import { generatePrintProfileForAsset, formatPrintProfileRow, setMakerWorldProfileId } from "../../../../../../lib/printProfile";
+import log from "electron-log/node";
+
+// POST /api/design/[designID]/asset/[assetID]/print-profile
+// (Re)generates the print profile for a 3MF asset by reading its slicer settings.
+// Used both to backfill assets added before this feature existed and to retry
+// extraction on demand.
+export async function POST(request, context) {
+  const { designID, assetID } = await context.params; // Await params
+  const db = getDatabase();
+
+  const username = request.headers.get('x-username') || 'default';
+
+  const designer = db.prepare(`
+    SELECT id FROM designer
+    WHERE username = ? AND deleted_at IS NULL AND status = 'active'
+  `).get(username);
+
+  if (!designer) {
+    return NextResponse.json({ error: 'Designer not found' }, { status: 404 });
+  }
+
+  const design = db.prepare(`
+    SELECT id FROM design
+    WHERE id = ? AND deleted_at IS NULL
+  `).get(designID);
+  if (!design) {
+    return NextResponse.json({ error: 'Design not found' }, { status: 404 });
+  }
+
+  const asset = db.prepare(`
+    SELECT id, file_ext, file_path FROM design_asset
+    WHERE id = ? AND design_id = ? AND deleted_at IS NULL
+  `).get(assetID, designID);
+  if (!asset) {
+    return NextResponse.json({ error: 'Asset not found' }, { status: 404 });
+  }
+
+  if (asset.file_ext.toLowerCase() !== '3mf') {
+    return NextResponse.json({ error: 'Print profiles can only be generated for .3mf assets' }, { status: 400 });
+  }
+
+  const appDataPath = process.env.NEXT_PUBLIC_APP_DATA_PATH || path.resolve('appdata');
+  const absoluteFilePath = path.join(appDataPath, asset.file_path);
+
+  try {
+    const profile = generatePrintProfileForAsset(db, asset.id, absoluteFilePath, { force: true });
+    return NextResponse.json({
+      print_profile: profile,
+      message: profile ? 'Print profile generated successfully' : 'No slicer print settings were found in this file',
+    }, { status: 200 });
+  } catch (error) {
+    log.error('Failed to generate print profile:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+// GET /api/design/[designID]/asset/[assetID]/print-profile
+// Returns the currently stored print profile, if any, without re-parsing the file.
+export async function GET(request, context) {
+  const { designID, assetID } = await context.params; // Await params
+  const db = getDatabase();
+
+  const asset = db.prepare(`
+    SELECT id FROM design_asset
+    WHERE id = ? AND design_id = ? AND deleted_at IS NULL
+  `).get(assetID, designID);
+  if (!asset) {
+    return NextResponse.json({ error: 'Asset not found' }, { status: 404 });
+  }
+
+  const row = db.prepare('SELECT * FROM print_profile WHERE design_asset_id = ?').get(asset.id);
+  return NextResponse.json({ print_profile: formatPrintProfileRow(row) }, { status: 200 });
+}
+
+// PATCH /api/design/[designID]/asset/[assetID]/print-profile
+// Records the MakerWorld draft/profile id this 3MF was uploaded as, so a later publish
+// updates that same MakerWorld instance instead of creating a duplicate.
+export async function PATCH(request, context) {
+  const { designID, assetID } = await context.params; // Await params
+  const db = getDatabase();
+
+  const asset = db.prepare(`
+    SELECT id FROM design_asset
+    WHERE id = ? AND design_id = ? AND deleted_at IS NULL
+  `).get(assetID, designID);
+  if (!asset) {
+    return NextResponse.json({ error: 'Asset not found' }, { status: 404 });
+  }
+
+  const body = await request.json();
+  const { makerworld_profile_id: makerworldProfileId } = body;
+  if (!makerworldProfileId) {
+    return NextResponse.json({ error: 'makerworld_profile_id is required' }, { status: 400 });
+  }
+
+  try {
+    setMakerWorldProfileId(db, asset.id, makerworldProfileId);
+    return NextResponse.json({ message: 'MakerWorld profile id recorded' }, { status: 200 });
+  } catch (error) {
+    log.error('Failed to record MakerWorld profile id:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/design/[designID]/asset/route.js
+++ b/src/app/api/design/[designID]/asset/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import {z} from "zod";
 import { getDatabase } from "../../../../lib/betterSqlite3";
+import { generatePrintProfileForAsset, getPrintProfilesByAssetIds } from "../../../../lib/printProfile";
 import log from "electron-log/node"
 import path from 'path';
 
@@ -35,7 +36,13 @@ export async function GET(request, context) {
     WHERE design_id = ? AND deleted_at IS NULL
   `).all(designID);
 
-  return NextResponse.json(assets);
+  const printProfilesByAssetId = getPrintProfilesByAssetIds(db, assets.map((asset) => asset.id));
+  const assetsWithProfiles = assets.map((asset) => ({
+    ...asset,
+    print_profile: printProfilesByAssetId[asset.id] || null,
+  }));
+
+  return NextResponse.json(assetsWithProfiles);
 }
 
 const assetCreateSchema = z.object({
@@ -80,7 +87,7 @@ export async function POST(request, context) {
 
   // Add file metadata to design_asset
   try {
-    db.prepare(`
+    const insertResult = db.prepare(`
     INSERT INTO design_asset (design_id, designer_id, file_name, file_ext, file_path, original_file_path, original_file_size, original_file_mtime, created_at)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
     `).run(
@@ -97,6 +104,14 @@ export async function POST(request, context) {
     db.prepare(
       `UPDATE design SET updated_at = datetime('now') WHERE id = ? AND designer_id = ?`
     ).run(designID, designer.id)
+
+    if (fileExt.toLowerCase() === '3mf') {
+      try {
+        generatePrintProfileForAsset(db, insertResult.lastInsertRowid, filePathAbs);
+      } catch (error) {
+        log.warn('Failed to generate print profile for new asset:', error);
+      }
+    }
 
     return NextResponse.json({ message: 'File metadata added successfully' }, { status: 200 });
   } catch (error) {

--- a/src/app/api/design/[designID]/route.js
+++ b/src/app/api/design/[designID]/route.js
@@ -1,6 +1,7 @@
 import {NextResponse} from 'next/server';
 import {getDatabase} from "../../../lib/betterSqlite3";
 import { designUpdateSchema, pubmanImageFileTypes } from "../../../components/design/types";
+import { getPrintProfilesByAssetIds } from "../../../lib/printProfile";
 import log from "electron-log/node";
 
 // TODO: Move this to a shared location
@@ -56,9 +57,12 @@ export async function GET(request, {params}) {
     const assets = db.prepare(`
           SELECT id, file_name, file_ext, file_path, original_file_path, original_file_size, original_file_mtime,
                  strftime('%Y-%m-%dT%H:%M:%fZ', created_at) AS created_at
-          FROM design_asset 
+          FROM design_asset
           WHERE design_id = ? AND deleted_at IS NULL
         `).all(design.id);
+
+    // Fetch print profiles for any 3MF assets
+    const printProfilesByAssetId = getPrintProfilesByAssetIds(db, assets.map((asset) => asset.id));
 
     // Fetch platform publishing information
     const platforms = db.prepare(`
@@ -99,6 +103,7 @@ export async function GET(request, {params}) {
         original_file_mtime: asset.original_file_mtime,
         url: `local://${asset.file_path}`,
         created_at: asset.created_at,
+        print_profile: printProfilesByAssetId[asset.id] || null,
       })),
       platforms: platforms.map((platform) => ({
         platform: platformMap[platform.platform_id] || 'UNKNOWN',

--- a/src/app/api/makerworld/makerworld-lib.js
+++ b/src/app/api/makerworld/makerworld-lib.js
@@ -485,6 +485,118 @@ export const UpdateDraftRequestSchema = z.object({
   scadIsVaildating: z.boolean().default(false),
 });
 
+// Request shape for MakerWorld's "add print profile" (their term for what shows as
+// "Print Profile" on a design page) action. Reverse-engineered from a real captured request
+// (2026-07-21) - do NOT reuse UpdateDraftRequestSchema for this; it's a different, narrower
+// shape keyed by mode: "addProfile", and parentId here is the MakerWorld DESIGN id, not a draft id.
+export const AddPrintProfileRequestSchema = z.object({
+  parentId: z.number(),
+  profileId: z.number().default(0),
+  mode: z.literal('addProfile').default('addProfile'),
+  clickWhich: z.string().default('publish'),
+  modelSource: z.string().default('profile'),
+  modelId: z.string().default(''),
+  title: z.string(),
+  profileTitle: z.string(),
+  profileSummary: z.string().default(''),
+  profileCover: z.string(),
+  model3Mf: z.object({
+    name: z.string().default(''),
+    url: z.string().default(''),
+    size: z.number().default(0),
+  }),
+  auxiliaryPictures: z.array(
+    z.object({
+      name: z.string().default(''),
+      url: z.string().default(''),
+      uploadUrl: z.string().default(''),
+      cdnPrefix: z.string().default(''),
+    })
+  ).default([]),
+  auxiliaryBom: z.array(z.any()).default([]),
+  auxiliaryGuide: z.array(z.any()).default([]),
+  auxiliaryOther: z.array(z.any()).default([]),
+  designBom: z.array(z.any()).default([]),
+  designGuide: z.array(z.any()).default([]),
+  designOther: z.array(z.any()).default([]),
+  designPictures: z.array(z.any()).default([]),
+  details: z.array(z.string()).default([]),
+  tempDetails: z.array(z.any()).default([]),
+  original: z.array(z.any()).default([]),
+  otherCompatibility: z.array(
+    z.object({
+      devModelName: z.string(),
+      devProductName: z.string(),
+      nozzleDiameter: z.number(),
+    })
+  ).default([]),
+  unsupportedDevModels: z.array(z.any()).default([]),
+  compatibility: z.object({
+    devModelName: z.string().default(''),
+    devProductName: z.string().default(''),
+    nozzleDiameter: z.number().default(0),
+  }).default({ devModelName: '', devProductName: '', nozzleDiameter: 0 }),
+  printer: z.object({
+    model: z.string().default(''),
+    variant: z.number().default(0),
+    settingsId: z.string().default(''),
+  }).default({ model: '', variant: 0, settingsId: '' }),
+  projectSettings: z.object({
+    layerHeight: z.string().default(''),
+    wallLoops: z.string().default(''),
+    sparseInfillDensity: z.string().default(''),
+  }).default({ layerHeight: '', wallLoops: '', sparseInfillDensity: '' }),
+  draftSetting: z.object({
+    customGCode: z.boolean().default(false),
+  }).default({ customGCode: false }),
+  instanceSetting: z.object({
+    submitAsPrivate: z.boolean().default(false),
+    isPrinterPresetChanged: z.boolean().default(true),
+    isPrinterTested: z.boolean().default(true),
+    isDonateToAuthor: z.boolean().default(false),
+    makerLab: z.string().default(''),
+    makerLabVersion: z.string().default(''),
+  }).default({
+    submitAsPrivate: false,
+    isPrinterPresetChanged: true,
+    isPrinterTested: true,
+    isDonateToAuthor: false,
+    makerLab: '',
+    makerLabVersion: '',
+  }),
+  makerLabSvg: z.array(z.any()).default([]),
+  syncToMWGlobal: z.boolean().default(true),
+  picturesIsUploading: z.boolean().default(false),
+  videosIsUploading: z.boolean().default(false),
+  accessoriesIsUploading: z.boolean().default(false),
+  profilePicturesIsUploading: z.boolean().default(false),
+  templateFileIsUploading: z.boolean().default(false),
+  modelDetailIsUploading: z.boolean().default(false),
+  rawModelFileIsUploading: z.boolean().default(false),
+  uploading3mfStatus: z.number().default(2),
+});
+
+// PubMan's parsed printer_model string -> MakerWorld's internal printer identifiers.
+// Every entry here was read directly off a real captured "add print profile" request - never
+// add an entry by guessing the code, since a wrong devModelName misrepresents printer
+// compatibility on a live listing. Printers not listed (e.g. "Bambu Lab A1 mini" as of
+// 2026-07-21) are unconfirmed; leave compatibility fields blank for those rather than guess.
+export const makerWorldPrinterDevModels = {
+  'Bambu Lab P1P': { devModelName: 'C11', devProductName: 'P1P' },
+  'Bambu Lab P1S': { devModelName: 'C12', devProductName: 'P1S' },
+  'Bambu Lab X1': { devModelName: 'BL-P002', devProductName: 'X1' },
+  'Bambu Lab X1 Carbon': { devModelName: 'BL-P001', devProductName: 'X1 Carbon' },
+  'Bambu Lab X1E': { devModelName: 'C13', devProductName: 'X1E' },
+  'Bambu Lab A1': { devModelName: 'N2S', devProductName: 'A1' },
+  'Bambu Lab P2S': { devModelName: 'N7', devProductName: 'P2S' },
+  'Bambu Lab X2D': { devModelName: 'N6', devProductName: 'X2D' },
+  'Bambu Lab A2L': { devModelName: 'N9', devProductName: 'A2L' },
+  'Bambu Lab H2D': { devModelName: 'O1D', devProductName: 'H2D' },
+  'Bambu Lab H2D Pro': { devModelName: 'O1E', devProductName: 'H2D Pro' },
+  'Bambu Lab H2S': { devModelName: 'O1S', devProductName: 'H2S' },
+  'Bambu Lab H2C': { devModelName: 'O1C2', devProductName: 'H2C' },
+};
+
 // --- End Zod Schemas ---
 
 export class MakerWorldAPI {

--- a/src/app/api/makerworld/makerworld-lib.test.js
+++ b/src/app/api/makerworld/makerworld-lib.test.js
@@ -1,0 +1,139 @@
+import { AddPrintProfileRequestSchema, makerWorldPrinterDevModels } from './makerworld-lib';
+
+// This is the exact request body captured from MakerWorld's own "Add Print Profile" UI
+// (2026-07-21, ExoGuitar - Neck - Neck v4, design id 3075097). It's the ground truth this
+// schema must keep matching - don't "clean it up" without re-verifying against a real capture.
+const REAL_CAPTURED_PAYLOAD = {
+  profileTitle: 'Metal Frets',
+  profileSummary: '',
+  profileCover: 'https://makerworld.bblmw.com/makerworld/model/20260722/2625562092/17922c675ff78059.jpeg',
+  modelId: '',
+  profileId: 0,
+  modelSource: 'profile',
+  auxiliaryPictures: [
+    {
+      name: 'exoguitar_neck_neck-v4--frets-plastic__photo--09_img-6459.jpeg',
+      url: 'https://makerworld.bblmw.com/makerworld/model/20260722/2625562092/17922c675ff78059.jpeg',
+      uploadUrl: 'https://or-cloud-makerworld-prod.s3.dualstack.us-west-2.amazonaws.com/makerworld/model/20260722/2625562092/17922c675ff78059.jpeg?X-Amz-Signature=stub',
+      cdnPrefix: 'https://makerworld.bblmw.com',
+    },
+  ],
+  auxiliaryBom: [],
+  auxiliaryGuide: [],
+  auxiliaryOther: [],
+  designBom: [],
+  designGuide: [],
+  designOther: [],
+  designPictures: [],
+  details: ['https://makerworld.bblmw.com/makerworld/model/20260722/2625562092/d94a1d831e4ba318.png'],
+  model3Mf: {
+    name: 'exoguitar_neck_neck-v4--frets-metal__print--frets-metal.3mf',
+    size: 3929948,
+    url: 'https://makerworld.bblmw.com/makerworld/model/20260722/2625562092/51d248fba354a492.3mf',
+  },
+  otherCompatibility: [
+    { devModelName: 'C11', devProductName: 'P1P', nozzleDiameter: 0.4 },
+    { devModelName: 'BL-P002', devProductName: 'X1', nozzleDiameter: 0.4 },
+    { devModelName: 'BL-P001', devProductName: 'X1 Carbon', nozzleDiameter: 0.4 },
+    { devModelName: 'C13', devProductName: 'X1E', nozzleDiameter: 0.4 },
+    { devModelName: 'N2S', devProductName: 'A1', nozzleDiameter: 0.4 },
+    { devModelName: 'O1D', devProductName: 'H2D', nozzleDiameter: 0.4 },
+    { devModelName: 'O1E', devProductName: 'H2D Pro', nozzleDiameter: 0.4 },
+    { devModelName: 'O1S', devProductName: 'H2S', nozzleDiameter: 0.4 },
+    { devModelName: 'N7', devProductName: 'P2S', nozzleDiameter: 0.4 },
+    { devModelName: 'O1C2', devProductName: 'H2C', nozzleDiameter: 0.4 },
+    { devModelName: 'N6', devProductName: 'X2D', nozzleDiameter: 0.4 },
+    { devModelName: 'N9', devProductName: 'A2L', nozzleDiameter: 0.4 },
+  ],
+  tempDetails: [
+    {
+      name: '2026-07-21_eebb6d68d28b2.png',
+      url: 'https://makerworld.bblmw.com/makerworld/model/20260722/2625562092/d94a1d831e4ba318.png',
+      uploadUrl: 'https://or-cloud-makerworld-prod.s3.dualstack.us-west-2.amazonaws.com/makerworld/model/20260722/2625562092/d94a1d831e4ba318.png?X-Amz-Signature=stub',
+      cdnPrefix: 'https://makerworld.bblmw.com',
+    },
+  ],
+  original: [],
+  picturesIsUploading: false,
+  videosIsUploading: false,
+  accessoriesIsUploading: false,
+  profilePicturesIsUploading: false,
+  templateFileIsUploading: false,
+  modelDetailIsUploading: false,
+  mode: 'addProfile',
+  clickWhich: 'publish',
+  rawModelFileIsUploading: false,
+  uploading3mfStatus: 2,
+  instanceSetting: {
+    submitAsPrivate: false,
+    isPrinterPresetChanged: true,
+    isPrinterTested: true,
+    isDonateToAuthor: false,
+    makerLab: '',
+    makerLabVersion: '',
+  },
+  unsupportedDevModels: [],
+  syncToMWGlobal: true,
+  parentId: 3075097,
+  compatibility: { devModelName: 'C12', devProductName: 'P1S', nozzleDiameter: 0.4 },
+  printer: { model: 'Bambu Lab P1S', variant: 0.4, settingsId: 'Bambu Lab P1S 0.4 nozzle' },
+  draftSetting: { customGCode: false },
+  projectSettings: { layerHeight: '0.28', wallLoops: '6', sparseInfillDensity: '55%' },
+  makerLabSvg: [],
+  title: 'Metal Frets',
+};
+
+describe('AddPrintProfileRequestSchema', () => {
+  it('parses the exact real captured payload without altering its key fields', () => {
+    const parsed = AddPrintProfileRequestSchema.parse(REAL_CAPTURED_PAYLOAD);
+
+    expect(parsed.parentId).toBe(3075097);
+    expect(parsed.mode).toBe('addProfile');
+    expect(parsed.profileId).toBe(0);
+    expect(parsed.modelSource).toBe('profile');
+    expect(parsed.title).toBe('Metal Frets');
+    expect(parsed.profileTitle).toBe('Metal Frets');
+    expect(parsed.model3Mf).toEqual(REAL_CAPTURED_PAYLOAD.model3Mf);
+    expect(parsed.printer).toEqual({ model: 'Bambu Lab P1S', variant: 0.4, settingsId: 'Bambu Lab P1S 0.4 nozzle' });
+    expect(parsed.compatibility).toEqual({ devModelName: 'C12', devProductName: 'P1S', nozzleDiameter: 0.4 });
+    expect(parsed.projectSettings).toEqual({ layerHeight: '0.28', wallLoops: '6', sparseInfillDensity: '55%' });
+    expect(parsed.instanceSetting.isPrinterPresetChanged).toBe(true);
+    expect(parsed.instanceSetting.isPrinterTested).toBe(true);
+    expect(parsed.otherCompatibility).toHaveLength(12);
+  });
+
+  it('parentId is required - this must be the MakerWorld design id, not a draft id', () => {
+    const { parentId, ...withoutParentId } = REAL_CAPTURED_PAYLOAD;
+    expect(() => AddPrintProfileRequestSchema.parse(withoutParentId)).toThrow();
+  });
+
+  it('applies the addProfile-specific defaults when only the required fields are given', () => {
+    const parsed = AddPrintProfileRequestSchema.parse({
+      parentId: 3075097,
+      title: 'My Profile',
+      profileTitle: 'My Profile',
+      profileCover: 'https://example.com/cover.jpeg',
+      model3Mf: { name: 'model.3mf', url: 'https://example.com/model.3mf', size: 123 },
+    });
+
+    expect(parsed.mode).toBe('addProfile');
+    expect(parsed.clickWhich).toBe('publish');
+    expect(parsed.modelSource).toBe('profile');
+    expect(parsed.uploading3mfStatus).toBe(2);
+    expect(parsed.instanceSetting.isPrinterPresetChanged).toBe(true);
+    expect(parsed.instanceSetting.isPrinterTested).toBe(true);
+    expect(parsed.compatibility).toEqual({ devModelName: '', devProductName: '', nozzleDiameter: 0 });
+  });
+});
+
+describe('makerWorldPrinterDevModels', () => {
+  it('maps confirmed printers to the devModelName/devProductName seen in the real capture', () => {
+    expect(makerWorldPrinterDevModels['Bambu Lab P1S']).toEqual({ devModelName: 'C12', devProductName: 'P1S' });
+    expect(makerWorldPrinterDevModels['Bambu Lab X1 Carbon']).toEqual({ devModelName: 'BL-P001', devProductName: 'X1 Carbon' });
+    expect(makerWorldPrinterDevModels['Bambu Lab X2D']).toEqual({ devModelName: 'N6', devProductName: 'X2D' });
+  });
+
+  it('does not guess a code for printers that were never confirmed by a real capture', () => {
+    expect(makerWorldPrinterDevModels['Bambu Lab A1 mini']).toBeUndefined();
+  });
+});

--- a/src/app/api/makerworld/sync/route.ts
+++ b/src/app/api/makerworld/sync/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getDatabase } from "../../../lib/betterSqlite3";
 import { makerWorldLicenseToPubman, makerWorldCategoryIdToPubman } from "../makerworld-lib";
 import { PLATFORM_IDS, PUBLISHED_STATUS } from "../../../lib/constants/platforms";
+import { generatePrintProfileForAsset } from "../../../lib/printProfile";
 import log from "electron-log/node";
 import path from "path";
 import { formatApiError } from "../../../lib/logApiError.js";
@@ -324,10 +325,18 @@ function createAssetRecord(
   `).get(designId, filePath);
 
   if (!existing) {
-    db.prepare(`
+    const insertResult = db.prepare(`
       INSERT INTO design_asset (design_id, designer_id, file_name, file_ext, file_path, original_file_size, created_at)
       VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
     `).run(designId, designerId, asset.fileName, asset.fileExt, filePath, asset.fileSize || null);
+
+    if (asset.fileExt.toLowerCase() === "3mf") {
+      try {
+        generatePrintProfileForAsset(db, insertResult.lastInsertRowid, asset.filePath);
+      } catch (error) {
+        log.warn("Failed to generate print profile for synced asset:", formatApiError(error));
+      }
+    }
   } else {
     // Update file size if it was missing
     if (asset.fileSize) {

--- a/src/app/components/design/makerworld-publishing.tsx
+++ b/src/app/components/design/makerworld-publishing.tsx
@@ -1,9 +1,13 @@
 'use client';
 
+import { useState, Fragment } from "react";
 import { PlatformPublishing, PlatformPublishingProps } from "./platform-publishing";
-import { isPubmanLicenseSupported, makerWorldImageFileTypes, licenseToMakerWorldMap, makerWorldCategories, UpdateDraftRequestSchema } from "@/src/app/api/makerworld/makerworld-lib";
+import { isPubmanLicenseSupported, makerWorldImageFileTypes, licenseToMakerWorldMap, makerWorldCategories, UpdateDraftRequestSchema, AddPrintProfileRequestSchema, makerWorldPrinterDevModels } from "@/src/app/api/makerworld/makerworld-lib";
 import { useMakerWorldAuth, MakerWorldUser } from "@/src/app/contexts/MakerWorldAuthContext";
 import { MakerWorldClientAPI, getMakerWorldStatusName } from "@/src/app/lib/makerworld-client";
+import { Button } from "@/src/app/components/ui/button";
+import { fetchDesign } from "@/src/app/actions/design";
+import { DesignSchema } from "@/src/app/components/design/types";
 import log from 'electron-log/renderer';
 
 // Browser-compatible path join (simple version for assets)
@@ -172,6 +176,7 @@ export function MakerWorldPublishing(props: PlatformPublishingProps) {
   const { isAuthenticated, accessToken, user } = useMakerWorldAuth();
 
   return (
+    <Fragment>
     <PlatformPublishing
       {...props}
       platformName="MakerWorld"
@@ -354,5 +359,161 @@ export function MakerWorldPublishing(props: PlatformPublishingProps) {
         };
       }}
     />
+    <MakerWorldPrintProfiles design={props.design} designID={props.designID} onDesignUpdated={props.onDesignUpdated} />
+    </Fragment>
+  );
+}
+
+// Create a MakerWorld "print profile" (their term - shows as "Print Profile" on the design
+// page) for a specific .3mf, as its own deliberate, user-confirmed action rather than an
+// automatic side effect of publishing. MakerWorld requires a real printed photo per profile
+// and discourages splitting one model into many profiles (see their upload guidelines), so this
+// is scoped to one asset at a time with a required photo, not a bulk loop over every 3mf.
+function MakerWorldPrintProfiles({ design, designID, onDesignUpdated }: { design: PlatformPublishingProps['design']; designID: string; onDesignUpdated: (design: DesignSchema) => void }) {
+  const { isAuthenticated, user } = useMakerWorldAuth();
+  const [busyAssetId, setBusyAssetId] = useState<string | null>(null);
+  const [titleByAsset, setTitleByAsset] = useState<Record<string, string>>({});
+  const [photoByAsset, setPhotoByAsset] = useState<Record<string, string>>({});
+  const [errorByAsset, setErrorByAsset] = useState<Record<string, string>>({});
+  const [createdAssetIds, setCreatedAssetIds] = useState<Set<string>>(new Set());
+
+  const mwPlatform = design.platforms.find(p => p.platform === "MAKERWORLD");
+  const threeMfAssets = design.assets.filter(a => a.file_ext.toLowerCase() === "3mf");
+  const imageAssets = design.assets.filter(a => makerWorldImageFileTypes.includes(a.file_ext.toLowerCase()));
+
+  // Only confirmed to work against a published design (parentId = the published MakerWorld
+  // design id) - that's the only case this was captured and verified against.
+  if (!isAuthenticated || !user) return null;
+  if (!mwPlatform?.platform_design_id || mwPlatform.published_status !== 2) return null;
+  if (threeMfAssets.length === 0) return null;
+
+  const handleCreate = async (asset: PlatformPublishingProps['design']['assets'][number]) => {
+    const title = (titleByAsset[asset.id] || asset.file_name.replace(/\.3mf$/i, "")).trim();
+    const photo = imageAssets.find(img => img.id === photoByAsset[asset.id]);
+    if (!title || !photo) return;
+
+    setBusyAssetId(asset.id);
+    setErrorByAsset(prev => ({ ...prev, [asset.id]: "" }));
+    try {
+      const api = new MakerWorldClientAPI();
+      const appDataPath = await getAppDataPath();
+
+      log.info(`[MakerWorld] Uploading print profile model + photo for ${asset.file_name}`);
+      const modelUpload = await uploadAsset(api, asset, user.uid, appDataPath);
+      const photoUpload = await uploadAsset(api, photo, user.uid, appDataPath);
+
+      const profile = asset.print_profile;
+      const printerModel = profile?.printer_model || "";
+      const knownPrinter = makerWorldPrinterDevModels[printerModel as keyof typeof makerWorldPrinterDevModels];
+
+      const payload = AddPrintProfileRequestSchema.parse({
+        parentId: Number(mwPlatform.platform_design_id),
+        title,
+        profileTitle: title,
+        profileCover: photoUpload.url,
+        auxiliaryPictures: [{ name: photo.file_name, url: photoUpload.url }],
+        model3Mf: { name: asset.file_name, url: modelUpload.url, size: modelUpload.size },
+        printer: {
+          model: printerModel,
+          variant: profile?.nozzle_diameter || 0,
+          settingsId: profile?.printer_settings_name || "",
+        },
+        compatibility: knownPrinter
+          ? { ...knownPrinter, nozzleDiameter: profile?.nozzle_diameter || 0 }
+          : undefined,
+        projectSettings: {
+          layerHeight: profile?.layer_height != null ? String(profile.layer_height) : "",
+          wallLoops: profile?.wall_loops != null ? String(profile.wall_loops) : "",
+          sparseInfillDensity: profile?.infill_density != null ? `${profile.infill_density}%` : "",
+        },
+      });
+
+      log.info(`[MakerWorld] Creating print profile "${title}" for ${asset.file_name}:`, payload);
+      const result = await api.createDraft(payload) as { id?: number };
+      log.info(`[MakerWorld] Print profile create response for ${asset.file_name}:`, result);
+
+      if (result?.id) {
+        // Creating the draft only saves it - it has to be submitted separately to actually publish.
+        log.info(`[MakerWorld] Submitting print profile draft ${result.id} for ${asset.file_name}`);
+        await api.publishDraft(result.id);
+
+        await fetch(`/api/design/${designID}/asset/${asset.id}/print-profile`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ makerworld_profile_id: String(result.id) }),
+        });
+        setCreatedAssetIds(prev => new Set(prev).add(asset.id));
+        const updatedDesign = await fetchDesign(designID);
+        onDesignUpdated(updatedDesign);
+      } else {
+        setErrorByAsset(prev => ({ ...prev, [asset.id]: "MakerWorld didn't return a profile id - check the log before retrying." }));
+      }
+    } catch (error) {
+      log.error(`[MakerWorld] Failed to create print profile for ${asset.file_name}:`, error);
+      setErrorByAsset(prev => ({ ...prev, [asset.id]: error instanceof Error ? error.message : "Failed to create print profile" }));
+    } finally {
+      setBusyAssetId(null);
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-lg p-6">
+      <h2 className="text-xl font-bold mb-1">MakerWorld Print Profiles</h2>
+      <p className="text-xs text-gray-500 mb-3">
+        MakerWorld requires a real printed photo for each profile - pick one per file and confirm to submit it.
+      </p>
+      <div className="space-y-3">
+        {threeMfAssets.map((asset) => {
+          const isCreated = !!asset.print_profile?.makerworld_profile_id || createdAssetIds.has(asset.id);
+          if (isCreated) {
+            return (
+              <div key={asset.id} className="text-sm text-green-700 flex items-center gap-2">
+                <span>✓</span><span>{asset.file_name} — profile created</span>
+              </div>
+            );
+          }
+
+          const printerModel = asset.print_profile?.printer_model;
+          const knownPrinter = printerModel ? makerWorldPrinterDevModels[printerModel as keyof typeof makerWorldPrinterDevModels] : undefined;
+          const isBusy = busyAssetId === asset.id;
+
+          return (
+            <div key={asset.id} className="border border-gray-200 rounded p-3 space-y-2">
+              <div className="text-sm font-medium">{asset.file_name}</div>
+              {printerModel && !knownPrinter && (
+                <div className="text-xs text-yellow-600">
+                  Printer &quot;{printerModel}&quot; isn&apos;t mapped to a MakerWorld printer code yet - submitting without a specific printer tag.
+                </div>
+              )}
+              <input
+                type="text"
+                placeholder="Profile title (e.g. Metal Frets)"
+                value={titleByAsset[asset.id] ?? ""}
+                onChange={(e) => setTitleByAsset(prev => ({ ...prev, [asset.id]: e.target.value }))}
+                className="w-full border border-gray-300 rounded px-2 py-1 text-sm"
+              />
+              <select
+                value={photoByAsset[asset.id] ?? ""}
+                onChange={(e) => setPhotoByAsset(prev => ({ ...prev, [asset.id]: e.target.value }))}
+                className="w-full border border-gray-300 rounded px-2 py-1 text-sm"
+              >
+                <option value="">Select a printed photo (required)…</option>
+                {imageAssets.map((img) => (
+                  <option key={img.id} value={img.id}>{img.file_name}</option>
+                ))}
+              </select>
+              {errorByAsset[asset.id] && <div className="text-xs text-red-600">{errorByAsset[asset.id]}</div>}
+              <Button
+                size="sm"
+                disabled={!photoByAsset[asset.id] || isBusy}
+                onClick={() => handleCreate(asset)}
+              >
+                {isBusy ? "Creating…" : "Create Print Profile"}
+              </Button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
   );
 }

--- a/src/app/components/design/makerworld-publishing.tsx
+++ b/src/app/components/design/makerworld-publishing.tsx
@@ -2,7 +2,7 @@
 
 import { useState, Fragment } from "react";
 import { PlatformPublishing, PlatformPublishingProps } from "./platform-publishing";
-import { isPubmanLicenseSupported, makerWorldImageFileTypes, licenseToMakerWorldMap, makerWorldCategories, UpdateDraftRequestSchema, AddPrintProfileRequestSchema, makerWorldPrinterDevModels } from "@/src/app/api/makerworld/makerworld-lib";
+import { isPubmanLicenseSupported, makerWorldImageFileTypes, licenseToMakerWorldMap, makerWorldCategories, UpdateDraftRequestSchema, makerWorldPrinterDevModels } from "@/src/app/api/makerworld/makerworld-lib";
 import { useMakerWorldAuth, MakerWorldUser } from "@/src/app/contexts/MakerWorldAuthContext";
 import { MakerWorldClientAPI, getMakerWorldStatusName } from "@/src/app/lib/makerworld-client";
 import { Button } from "@/src/app/components/ui/button";
@@ -395,59 +395,26 @@ function MakerWorldPrintProfiles({ design, designID, onDesignUpdated }: { design
     setBusyAssetId(asset.id);
     setErrorByAsset(prev => ({ ...prev, [asset.id]: "" }));
     try {
-      const api = new MakerWorldClientAPI();
-      const appDataPath = await getAppDataPath();
-
-      log.info(`[MakerWorld] Uploading print profile model + photo for ${asset.file_name}`);
-      const modelUpload = await uploadAsset(api, asset, user.uid, appDataPath);
-      const photoUpload = await uploadAsset(api, photo, user.uid, appDataPath);
-
-      const profile = asset.print_profile;
-      const printerModel = profile?.printer_model || "";
-      const knownPrinter = makerWorldPrinterDevModels[printerModel as keyof typeof makerWorldPrinterDevModels];
-
-      const payload = AddPrintProfileRequestSchema.parse({
-        parentId: Number(mwPlatform.platform_design_id),
-        title,
-        profileTitle: title,
-        profileCover: photoUpload.url,
-        auxiliaryPictures: [{ name: photo.file_name, url: photoUpload.url }],
-        model3Mf: { name: asset.file_name, url: modelUpload.url, size: modelUpload.size },
-        printer: {
-          model: printerModel,
-          variant: profile?.nozzle_diameter || 0,
-          settingsId: profile?.printer_settings_name || "",
-        },
-        compatibility: knownPrinter
-          ? { ...knownPrinter, nozzleDiameter: profile?.nozzle_diameter || 0 }
-          : undefined,
-        projectSettings: {
-          layerHeight: profile?.layer_height != null ? String(profile.layer_height) : "",
-          wallLoops: profile?.wall_loops != null ? String(profile.wall_loops) : "",
-          sparseInfillDensity: profile?.infill_density != null ? `${profile.infill_density}%` : "",
-        },
+      // The whole create+upload+submit flow runs server-side (reading files off disk and
+      // talking to MakerWorld both happen in the API route) so this works whether PubMan is
+      // driven from the packaged Electron window or any other HTTP client against the same
+      // server - no window.electron/IPC dependency here.
+      log.info(`[MakerWorld] Creating print profile "${title}" for ${asset.file_name}`);
+      const response = await fetch(`/api/design/${designID}/asset/${asset.id}/print-profile/makerworld`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title, photo_asset_id: photo.id }),
       });
+      const result = await response.json();
 
-      log.info(`[MakerWorld] Creating print profile "${title}" for ${asset.file_name}:`, payload);
-      const result = await api.createDraft(payload) as { id?: number };
-      log.info(`[MakerWorld] Print profile create response for ${asset.file_name}:`, result);
-
-      if (result?.id) {
-        // Creating the draft only saves it - it has to be submitted separately to actually publish.
-        log.info(`[MakerWorld] Submitting print profile draft ${result.id} for ${asset.file_name}`);
-        await api.publishDraft(result.id);
-
-        await fetch(`/api/design/${designID}/asset/${asset.id}/print-profile`, {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ makerworld_profile_id: String(result.id) }),
-        });
-        setCreatedAssetIds(prev => new Set(prev).add(asset.id));
-        const updatedDesign = await fetchDesign(designID);
-        onDesignUpdated(updatedDesign);
-      } else {
-        setErrorByAsset(prev => ({ ...prev, [asset.id]: "MakerWorld didn't return a profile id - check the log before retrying." }));
+      if (!response.ok) {
+        throw new Error(result?.error || `Failed to create print profile (${response.status})`);
       }
+
+      log.info(`[MakerWorld] Print profile created for ${asset.file_name}: id=${result.makerworld_profile_id}`);
+      setCreatedAssetIds(prev => new Set(prev).add(asset.id));
+      const updatedDesign = await fetchDesign(designID);
+      onDesignUpdated(updatedDesign);
     } catch (error) {
       log.error(`[MakerWorld] Failed to create print profile for ${asset.file_name}:`, error);
       setErrorByAsset(prev => ({ ...prev, [asset.id]: error instanceof Error ? error.message : "Failed to create print profile" }));

--- a/src/app/components/design/types.ts
+++ b/src/app/components/design/types.ts
@@ -202,6 +202,28 @@ export const makerWorldCategories = z.enum([
 
 export const pubmanImageFileTypes = ['jpg', 'jpeg', 'png', 'webp', 'gif', 'heic', 'heif', 'svg'];
 
+export const printProfileSchema = z.object({
+    printer_model: z.string().nullable(),
+    printer_settings_name: z.string().nullable(),
+    nozzle_diameter: z.number().nullable(),
+    bed_type: z.string().nullable(),
+    layer_height: z.number().nullable(),
+    first_layer_height: z.number().nullable(),
+    wall_loops: z.number().nullable(),
+    infill_density: z.number().nullable(),
+    infill_pattern: z.string().nullable(),
+    supports_enabled: z.boolean(),
+    support_type: z.string().nullable(),
+    print_settings_name: z.string().nullable(),
+    filament_types: z.array(z.string()),
+    filament_colors: z.array(z.string()),
+    filament_names: z.array(z.string()),
+    plate_count: z.number().nullable(),
+    makerworld_profile_id: z.string().nullable(),
+});
+
+export type PrintProfileSchema = z.infer<typeof printProfileSchema>
+
 export const designSchema = z.object({
     id: z.string(),
     main_name: z.string(),
@@ -227,6 +249,7 @@ export const designSchema = z.object({
             original_file_mtime: z.string().datetime({ offset: false }).nullish(),
             url: z.string(),
             created_at: z.string().datetime({ offset: false }),
+            print_profile: printProfileSchema.nullish(),
         }),
     ),
     platforms: z.array(

--- a/src/app/design/[designID]/page.tsx
+++ b/src/app/design/[designID]/page.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import path from "path";
-import { useState, useEffect } from "react";
+import { useState, useEffect, Fragment } from "react";
 import { useParams } from "next/navigation";
 import { Button } from "@/src/app/components/ui/button";
 import { fetchDesign, updateDesign } from "@/src/app/actions/design";
 import { DesignSchema, thingiverseCategories, pubmanImageFileTypes } from "@/src/app/components/design/types";
 import {FieldValues, useForm} from 'react-hook-form';
-import {addFile, removeFile} from "@/src/app/actions/file";
+import {addFile, removeFile, generatePrintProfile} from "@/src/app/actions/file";
 import {Input} from "@/src/app/components/ui/input";
 import {useRouter} from "next/navigation";
 import { ThingiversePublishing } from "@/src/app/components/design/thingiverse-publishing";
@@ -18,7 +18,7 @@ import {printablesCategories} from "@/src/app/api/printables/printables-lib";
 import {makerWorldCategories} from "@/src/app/api/makerworld/makerworld-lib";
 import {MakerWorldPublishing} from "@/src/app/components/design/makerworld-publishing";
 import Image from 'next/image';
-import {CircleDashed, ExternalLinkIcon, RefreshCwIcon} from "lucide-react";
+import {CircleDashed, ChevronDown, ExternalLinkIcon, RefreshCwIcon} from "lucide-react";
 
 const getLicenseName = (licenseKey: string): string => {
   const licenseMap: Record<string, string> = {
@@ -157,6 +157,43 @@ const DesignDetailsPage = () => {
     } catch (error) {
       log.error(error);
       setErrorMessage("Failed to remove file.");
+    }
+  };
+
+  // Print profile UI state: which 3MF rows are expanded, and which are mid-extraction
+  const [expandedProfileIds, setExpandedProfileIds] = useState<Set<string>>(new Set());
+  const [generatingProfileIds, setGeneratingProfileIds] = useState<Set<string>>(new Set());
+
+  const toggleProfileExpanded = (assetID: string) => {
+    setExpandedProfileIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(assetID)) {
+        next.delete(assetID);
+      } else {
+        next.add(assetID);
+      }
+      return next;
+    });
+  };
+
+  const handleGenerateProfile = async (assetID: string) => {
+    if (!designID) return;
+
+    setGeneratingProfileIds((prev) => new Set(prev).add(assetID));
+    try {
+      await generatePrintProfile(designID.toString(), assetID);
+      const updatedDesign = await fetchDesign(designID.toString());
+      setDesign(updatedDesign);
+      setExpandedProfileIds((prev) => new Set(prev).add(assetID));
+    } catch (error) {
+      log.error(error);
+      setErrorMessage("Failed to read print settings from file.");
+    } finally {
+      setGeneratingProfileIds((prev) => {
+        const next = new Set(prev);
+        next.delete(assetID);
+        return next;
+      });
     }
   };
 
@@ -582,53 +619,160 @@ const DesignDetailsPage = () => {
               {design.assets && design.assets.filter(asset => !pubmanImageFileTypes.includes(asset.file_ext?.toLowerCase())).length > 0 ? (
                 design.assets.filter(asset => !pubmanImageFileTypes.includes(asset.file_ext?.toLowerCase())).map((asset) => {
                   const status = fileStatus[asset.id];
+                  const is3mf = asset.file_ext?.toLowerCase() === '3mf';
+                  const profile = asset.print_profile;
+                  const isExpanded = expandedProfileIds.has(asset.id);
+                  const isGenerating = generatingProfileIds.has(asset.id);
                   return (
-                    <tr key={asset.id} className="align-middle">
-                      <td className="px-4 py-2 flex gap-3 items-center">
-                        <div className="w-18 h-18 flex items-center justify-center bg-gray-200 rounded text-gray-600 text-base font-bold">
-                          {asset.file_ext?.toUpperCase() || '?'}
-                        </div>
-                        <div>{asset.file_name}</div>
-                      </td>
-                      <td className="px-4 py-2 text-sm text-gray-700">{formatBytes(asset.original_file_size)}</td>
-                      <td className="px-4 py-2 text-xs text-gray-500">{asset.original_file_mtime ? new Date(asset.original_file_mtime).toLocaleString() : '-'}</td>
-                      <td className="px-4 py-2">
-                        {asset.original_file_path ? (
-                          <div className="flex items-center gap-2">
-                            {status && !status.exists ? (
-                              <div
-                                className="text-red-500 cursor-help border border-red-200 bg-red-50 rounded text-xs inline-flex items-center p-1"
-                                title={`File not found:\n${asset.original_file_path}`}
-                              >
-                                <CircleDashed className="h-4 w-4 inline mr-1" />
-                                <span>Missing</span>
-                              </div>
-                            ) : (
-                              <Button size="sm" variant="outline" onClick={
-                                // @ts-expect-error electron is defined in preload script
-                                () => window.electron.shell.showItemInFolder(asset.original_file_path)
-                              } title={`Show in Finder:\n${asset.original_file_path}`} className="p-1 h-7 w-7 min-w-0">
-                                <ExternalLinkIcon/>
-                              </Button>
-                            )}
-                            {status ? (
-                              status.exists ? (
-                                status.modified ? (
-                                  <span title="File has been modified since import" className="text-yellow-500">⚠️</span>
-                                ) : (
-                                  <span title="File is unchanged" className="text-green-500">
-                                    <RefreshCwIcon width={16} height={16}/>
-                                  </span>
-                                )
-                              ) : null
-                            ) : (<span className="text-gray-500">-</span>)}
+                    <Fragment key={asset.id}>
+                      <tr className="align-middle">
+                        <td className="px-4 py-2 flex gap-3 items-center">
+                          <div className="w-18 h-18 flex items-center justify-center bg-gray-200 rounded text-gray-600 text-base font-bold shrink-0">
+                            {asset.file_ext?.toUpperCase() || '?'}
                           </div>
-                        ) : (<span className="text-gray-500">-</span>)}
-                      </td>
-                      <td className="px-4 py-2">
-                        <Button onClick={() => handleFileRemove(asset.id)} variant="destructive" size="sm">Remove</Button>
-                      </td>
-                    </tr>
+                          <div className="min-w-0">
+                            <div className="flex items-center gap-1.5">
+                              <span>{asset.file_name}</span>
+                              {is3mf && profile && (
+                                <button
+                                  type="button"
+                                  onClick={() => toggleProfileExpanded(asset.id)}
+                                  className="text-gray-400 hover:text-gray-600"
+                                  title={isExpanded ? "Hide print settings" : "Show print settings"}
+                                >
+                                  <ChevronDown width={14} height={14} className={isExpanded ? "rotate-180 transition-transform" : "transition-transform"} />
+                                </button>
+                              )}
+                            </div>
+                            {is3mf && profile && (
+                              <div className="text-xs text-gray-500 mt-0.5 truncate">
+                                {profile.printer_model || 'Unknown printer'}
+                                {profile.layer_height != null && ` • ${profile.layer_height}mm layer`}
+                                {profile.infill_density != null && ` • ${profile.infill_density}% infill`}
+                              </div>
+                            )}
+                            {is3mf && !profile && (
+                              <button
+                                type="button"
+                                onClick={() => handleGenerateProfile(asset.id)}
+                                disabled={isGenerating}
+                                className="text-xs text-blue-600 hover:underline mt-0.5 disabled:text-gray-400 disabled:no-underline"
+                              >
+                                {isGenerating ? 'Reading print settings…' : 'Read print settings'}
+                              </button>
+                            )}
+                          </div>
+                        </td>
+                        <td className="px-4 py-2 text-sm text-gray-700">{formatBytes(asset.original_file_size)}</td>
+                        <td className="px-4 py-2 text-xs text-gray-500">{asset.original_file_mtime ? new Date(asset.original_file_mtime).toLocaleString() : '-'}</td>
+                        <td className="px-4 py-2">
+                          {asset.original_file_path ? (
+                            <div className="flex items-center gap-2">
+                              {status && !status.exists ? (
+                                <div
+                                  className="text-red-500 cursor-help border border-red-200 bg-red-50 rounded text-xs inline-flex items-center p-1"
+                                  title={`File not found:\n${asset.original_file_path}`}
+                                >
+                                  <CircleDashed className="h-4 w-4 inline mr-1" />
+                                  <span>Missing</span>
+                                </div>
+                              ) : (
+                                <Button size="sm" variant="outline" onClick={
+                                  // @ts-expect-error electron is defined in preload script
+                                  () => window.electron.shell.showItemInFolder(asset.original_file_path)
+                                } title={`Show in Finder:\n${asset.original_file_path}`} className="p-1 h-7 w-7 min-w-0">
+                                  <ExternalLinkIcon/>
+                                </Button>
+                              )}
+                              {status ? (
+                                status.exists ? (
+                                  status.modified ? (
+                                    <span title="File has been modified since import" className="text-yellow-500">⚠️</span>
+                                  ) : (
+                                    <span title="File is unchanged" className="text-green-500">
+                                      <RefreshCwIcon width={16} height={16}/>
+                                    </span>
+                                  )
+                                ) : null
+                              ) : (<span className="text-gray-500">-</span>)}
+                            </div>
+                          ) : (<span className="text-gray-500">-</span>)}
+                        </td>
+                        <td className="px-4 py-2">
+                          <Button onClick={() => handleFileRemove(asset.id)} variant="destructive" size="sm">Remove</Button>
+                        </td>
+                      </tr>
+                      {is3mf && profile && isExpanded && (
+                        <tr>
+                          <td colSpan={5} className="px-4 pb-4 bg-gray-50">
+                            <div className="grid grid-cols-2 sm:grid-cols-4 gap-x-6 gap-y-2 text-xs text-gray-700 pt-3">
+                              <div>
+                                <div className="text-gray-400">Printer</div>
+                                {profile.printer_model || '—'}
+                              </div>
+                              <div>
+                                <div className="text-gray-400">Nozzle</div>
+                                {profile.nozzle_diameter != null ? `${profile.nozzle_diameter}mm` : '—'}
+                              </div>
+                              <div>
+                                <div className="text-gray-400">Bed</div>
+                                {profile.bed_type || '—'}
+                              </div>
+                              <div>
+                                <div className="text-gray-400">Layer height</div>
+                                {profile.layer_height != null ? `${profile.layer_height}mm (first ${profile.first_layer_height ?? '—'}mm)` : '—'}
+                              </div>
+                              <div>
+                                <div className="text-gray-400">Walls</div>
+                                {profile.wall_loops ?? '—'}
+                              </div>
+                              <div>
+                                <div className="text-gray-400">Infill</div>
+                                {profile.infill_density != null ? `${profile.infill_density}% ${profile.infill_pattern || ''}` : '—'}
+                              </div>
+                              <div>
+                                <div className="text-gray-400">Supports</div>
+                                {profile.supports_enabled ? (profile.support_type || 'On') : 'Off'}
+                              </div>
+                              <div>
+                                <div className="text-gray-400">Plates</div>
+                                {profile.plate_count ?? '—'}
+                              </div>
+                              <div className="col-span-2 sm:col-span-4">
+                                <div className="text-gray-400">Profile</div>
+                                {profile.print_settings_name || '—'}
+                              </div>
+                              {profile.filament_types.length > 0 && (
+                                <div className="col-span-2 sm:col-span-4">
+                                  <div className="text-gray-400 mb-1">Filament</div>
+                                  <div className="flex flex-wrap gap-2">
+                                    {profile.filament_types.map((type, i) => (
+                                      <span key={i} className="inline-flex items-center gap-1.5 bg-white border border-gray-200 rounded px-1.5 py-0.5">
+                                        <span
+                                          className="w-3 h-3 rounded-full border border-gray-300 shrink-0"
+                                          style={{ backgroundColor: profile.filament_colors[i] || '#cccccc' }}
+                                        />
+                                        {type}
+                                      </span>
+                                    ))}
+                                  </div>
+                                </div>
+                              )}
+                              <div className="col-span-2 sm:col-span-4">
+                                <button
+                                  type="button"
+                                  onClick={() => handleGenerateProfile(asset.id)}
+                                  disabled={isGenerating}
+                                  className="text-blue-600 hover:underline disabled:text-gray-400 disabled:no-underline"
+                                >
+                                  {isGenerating ? 'Re-reading…' : 'Re-read print settings'}
+                                </button>
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </Fragment>
                   );
                 })
               ) : (

--- a/src/app/lib/makerworldServer.js
+++ b/src/app/lib/makerworldServer.js
@@ -1,0 +1,146 @@
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import crypto from 'crypto';
+import log from 'electron-log/node';
+
+// Server-side equivalent of the renderer's window.electron.makerworld.fetch IPC bridge
+// (electron/main.ts's "makerworld:fetch" handler). This works - and only works - when
+// Next.js's server is started in-process with Electron's main process (see
+// startNextJSServer() in electron/main.ts, which calls next's startServer() directly rather
+// than spawning a child process, and only in production - "next dev" runs as a genuinely
+// separate plain Node process), so `session` here is the real Electron API, not the string
+// the 'electron' package resolves to when required from a plain, non-Electron Node process.
+// This lets MakerWorld actions be driven over plain HTTP (e.g. browser automation hitting the
+// app's port directly) without needing the Electron renderer/preload context at all.
+//
+// `electron` MUST be imported dynamically (not as a static top-level import): Next's build step
+// ("next build") and "next dev" both load this module in a plain Node process to statically
+// analyze it, and a static `import ... from 'electron'` throws immediately in that context
+// ("Electron failed to install correctly") - which would break the production build itself, not
+// just dev. A dynamic import here defers that resolution to when a request actually invokes
+// this function, which in production only happens inside Electron's own process.
+async function getMakerWorldSession() {
+  const electron = await import('electron');
+  return electron.session.fromPartition('persist:makerworld');
+}
+
+const MW_API_URL = 'https://makerworld.com/api';
+const BBL_API_URL = 'https://api.bambulab.com';
+
+const ALLOWED_MAKERWORLD_DOMAINS = ['makerworld.com', 'api.bambulab.com', 'bambulab.com'];
+
+function extractApiErrorDetail(responseBody) {
+  if (!responseBody) return undefined;
+  try {
+    const parsed = JSON.parse(responseBody);
+    if (typeof parsed?.error === 'string') return parsed.error;
+    if (typeof parsed?.message === 'string') return parsed.message;
+  } catch {
+    // Not JSON - nothing to extract.
+  }
+  return undefined;
+}
+
+async function makerWorldSessionFetch(url, options = {}) {
+  const parsedUrl = new URL(url);
+  const isAllowedDomain = ALLOWED_MAKERWORLD_DOMAINS.some(
+    (domain) => parsedUrl.hostname === domain || parsedUrl.hostname.endsWith(`.${domain}`)
+  );
+  if (!isAllowedDomain) {
+    throw new Error(`Request to unauthorized domain: ${parsedUrl.hostname}`);
+  }
+
+  const method = options.method || 'GET';
+  log.info(`[MakerWorld API server] >>> ${method} ${url}`);
+  if (options.body) {
+    log.info(`[MakerWorld API server] >>> Request body:`, options.body);
+  }
+
+  const sess = await getMakerWorldSession();
+  const response = await sess.fetch(url, {
+    method,
+    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+    body: options.body,
+  });
+  const body = await response.text();
+  log.info(`[MakerWorld API server] <<< ${response.status} ${response.statusText}`);
+
+  if (!response.ok) {
+    const detail = extractApiErrorDetail(body);
+    const message = detail
+      ? `MakerWorld API error: ${response.status} ${response.statusText} - ${detail}`
+      : `MakerWorld API error: ${response.status} ${response.statusText}`;
+    log.error(`[MakerWorld API server] Request failed: ${message} | url=${url} | responseBody=${body}`);
+    throw new Error(message);
+  }
+
+  try {
+    return body ? JSON.parse(body) : null;
+  } catch {
+    throw new Error('Failed to parse MakerWorld response as JSON');
+  }
+}
+
+export async function getMakerWorldUserInfo() {
+  return makerWorldSessionFetch(`${BBL_API_URL}/v1/design-user-service/my/preference`);
+}
+
+export async function getMakerWorldS3Config() {
+  return makerWorldSessionFetch(`${MW_API_URL}/v1/user-service/my/s3config?useType=1`);
+}
+
+export async function createMakerWorldDraft(draftData) {
+  return makerWorldSessionFetch(`${MW_API_URL}/v1/design-service/my/draft`, {
+    method: 'POST',
+    body: JSON.stringify(draftData),
+  });
+}
+
+export async function updateMakerWorldDraft(draftId, draftData) {
+  return makerWorldSessionFetch(`${MW_API_URL}/v1/design-service/my/draft/${draftId}`, {
+    method: 'PUT',
+    body: JSON.stringify(draftData),
+  });
+}
+
+export async function submitMakerWorldDraft(draftId) {
+  return makerWorldSessionFetch(`${MW_API_URL}/v1/design-service/my/draft/${draftId}/submit`, {
+    method: 'POST',
+  });
+}
+
+// Mirrors MakerWorldClientAPI.uploadFileToS3 - this part never needed Electron IPC even
+// client-side, since presigned-URL S3 uploads go straight to AWS, not through MakerWorld's
+// Cloudflare-fronted domains. Kept here too so the whole print-profile flow lives server-side.
+export async function uploadFileToMakerWorldS3(fileName, fileBuffer, userId, s3Config) {
+  const today = new Date().toISOString().slice(0, 10);
+  const randomHex = crypto.randomBytes(8).toString('hex');
+  const fileExt = fileName.includes('.') ? fileName.split('.').pop() : 'bin';
+  const key = `makerworld/user/${userId}/draft/${today}_${randomHex}.${fileExt}`;
+
+  log.info(`[MakerWorld S3 server] >>> PUT s3://${s3Config.bucketName}/${key} (${fileBuffer.length} bytes)`);
+
+  const client = new S3Client({
+    region: s3Config.region,
+    endpoint: `https://${s3Config.endpoint}`,
+    credentials: {
+      accessKeyId: s3Config.accessKeyId,
+      secretAccessKey: s3Config.accessKeySecret,
+      sessionToken: s3Config.securityToken,
+    },
+  });
+
+  // Sanitize filename for the Content-Disposition header to prevent header injection
+  const sanitizedFileName = fileName.replace(/[\x00-\x1F\x7F"\\]/g, '_');
+
+  await client.send(new PutObjectCommand({
+    Bucket: s3Config.bucketName,
+    Key: key,
+    Body: fileBuffer,
+    ContentDisposition: `attachment; filename="${sanitizedFileName}"`,
+    ContentType: 'application/octet-stream',
+  }));
+
+  const url = `${s3Config.cdnUrl}/${key}`;
+  log.info(`[MakerWorld S3 server] <<< Upload successful: ${url}`);
+  return { url };
+}

--- a/src/app/lib/makerworldServer.js
+++ b/src/app/lib/makerworldServer.js
@@ -24,7 +24,6 @@ async function getMakerWorldSession() {
 }
 
 const MW_API_URL = 'https://makerworld.com/api';
-const BBL_API_URL = 'https://api.bambulab.com';
 
 const ALLOWED_MAKERWORLD_DOMAINS = ['makerworld.com', 'api.bambulab.com', 'bambulab.com'];
 
@@ -78,10 +77,6 @@ async function makerWorldSessionFetch(url, options = {}) {
   } catch {
     throw new Error('Failed to parse MakerWorld response as JSON');
   }
-}
-
-export async function getMakerWorldUserInfo() {
-  return makerWorldSessionFetch(`${BBL_API_URL}/v1/design-user-service/my/preference`);
 }
 
 export async function getMakerWorldS3Config() {

--- a/src/app/lib/printProfile.js
+++ b/src/app/lib/printProfile.js
@@ -1,0 +1,210 @@
+import AdmZip from 'adm-zip';
+import log from 'electron-log/node';
+
+const PROJECT_SETTINGS_ENTRY = 'Metadata/project_settings.config';
+const MODEL_SETTINGS_ENTRY = 'Metadata/model_settings.config';
+const PLATE_JSON_RE = /^Metadata\/plate_\d+\.json$/;
+const PLATE_TAG_RE = /<plate(?:\s|>)/g;
+
+function firstOf(value) {
+  if (Array.isArray(value)) return value.length > 0 ? value[0] : null;
+  return value === undefined ? null : value;
+}
+
+function toNumber(value) {
+  if (value === undefined || value === null) return null;
+  const n = parseFloat(String(value).replace('%', ''));
+  return Number.isFinite(n) ? n : null;
+}
+
+function toStringArray(value) {
+  return Array.isArray(value) ? value.filter((v) => typeof v === 'string') : [];
+}
+
+function countPlates(zip) {
+  const plateJsonCount = zip.getEntries().filter((e) => PLATE_JSON_RE.test(e.entryName)).length;
+  if (plateJsonCount > 0) return plateJsonCount;
+
+  const modelSettings = zip.getEntry(MODEL_SETTINGS_ENTRY);
+  if (!modelSettings) return null;
+  const matches = modelSettings.getData().toString('utf-8').match(PLATE_TAG_RE);
+  return matches ? matches.length : null;
+}
+
+/**
+ * Extract Bambu Studio / OrcaSlicer print settings from a .3mf project file.
+ * Accepts either an absolute file path or an in-memory Buffer (both supported by adm-zip).
+ * Returns null for 3MF files that aren't a recognized slicer project (e.g. plain mesh exports).
+ */
+export function parseThreeMfPrintProfile(pathOrBuffer) {
+  let zip;
+  try {
+    zip = new AdmZip(pathOrBuffer);
+  } catch (error) {
+    log.warn('[PrintProfile] Could not open file as a zip/3mf archive:', error);
+    return null;
+  }
+
+  const settingsEntry = zip.getEntry(PROJECT_SETTINGS_ENTRY);
+  if (!settingsEntry) {
+    // Not a Bambu Studio / OrcaSlicer project 3MF - nothing to extract
+    return null;
+  }
+
+  let settings;
+  try {
+    settings = JSON.parse(settingsEntry.getData().toString('utf-8'));
+  } catch (error) {
+    log.warn('[PrintProfile] Failed to parse project_settings.config as JSON:', error);
+    return null;
+  }
+
+  return {
+    printer_model: settings.printer_model || null,
+    printer_settings_name: settings.printer_settings_id || null,
+    nozzle_diameter: toNumber(firstOf(settings.nozzle_diameter)),
+    bed_type: settings.curr_bed_type || null,
+    layer_height: toNumber(settings.layer_height),
+    first_layer_height: toNumber(settings.initial_layer_print_height),
+    wall_loops: toNumber(settings.wall_loops),
+    infill_density: toNumber(settings.sparse_infill_density),
+    infill_pattern: settings.sparse_infill_pattern || null,
+    supports_enabled: settings.enable_support === '1' || settings.enable_support === 1,
+    support_type: settings.support_type || null,
+    print_settings_name: settings.print_settings_id || null,
+    filament_types: toStringArray(settings.filament_type),
+    filament_colors: toStringArray(settings.filament_colour),
+    filament_names: toStringArray(settings.filament_settings_id),
+    plate_count: countPlates(zip),
+  };
+}
+
+function upsertPrintProfile(db, assetId, profile) {
+  db.prepare(`
+    INSERT INTO print_profile (
+      design_asset_id, printer_model, printer_settings_name, nozzle_diameter, bed_type,
+      layer_height, first_layer_height, wall_loops, infill_density, infill_pattern,
+      supports_enabled, support_type, print_settings_name, filament_types, filament_colors,
+      filament_names, plate_count, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+    ON CONFLICT(design_asset_id) DO UPDATE SET
+      printer_model = excluded.printer_model,
+      printer_settings_name = excluded.printer_settings_name,
+      nozzle_diameter = excluded.nozzle_diameter,
+      bed_type = excluded.bed_type,
+      layer_height = excluded.layer_height,
+      first_layer_height = excluded.first_layer_height,
+      wall_loops = excluded.wall_loops,
+      infill_density = excluded.infill_density,
+      infill_pattern = excluded.infill_pattern,
+      supports_enabled = excluded.supports_enabled,
+      support_type = excluded.support_type,
+      print_settings_name = excluded.print_settings_name,
+      filament_types = excluded.filament_types,
+      filament_colors = excluded.filament_colors,
+      filament_names = excluded.filament_names,
+      plate_count = excluded.plate_count,
+      updated_at = CURRENT_TIMESTAMP
+  `).run(
+    assetId,
+    profile.printer_model,
+    profile.printer_settings_name,
+    profile.nozzle_diameter,
+    profile.bed_type,
+    profile.layer_height,
+    profile.first_layer_height,
+    profile.wall_loops,
+    profile.infill_density,
+    profile.infill_pattern,
+    profile.supports_enabled ? 1 : 0,
+    profile.support_type,
+    profile.print_settings_name,
+    JSON.stringify(profile.filament_types),
+    JSON.stringify(profile.filament_colors),
+    JSON.stringify(profile.filament_names),
+    profile.plate_count
+  );
+}
+
+/**
+ * Parse a design_asset's 3MF file (by absolute path) and store the result as its print profile.
+ * No-op if a profile already exists for this asset, unless options.force is set.
+ * Never throws - extraction is best-effort and safe to call inline from asset creation flows.
+ */
+export function generatePrintProfileForAsset(db, assetId, absoluteFilePath, options = {}) {
+  const { force = false } = options;
+
+  if (!force) {
+    const existing = db.prepare('SELECT id FROM print_profile WHERE design_asset_id = ?').get(assetId);
+    if (existing) return null;
+  }
+
+  let profile;
+  try {
+    profile = parseThreeMfPrintProfile(absoluteFilePath);
+  } catch (error) {
+    log.warn(`[PrintProfile] Failed to extract print profile for asset ${assetId}:`, error);
+    return null;
+  }
+  if (!profile) return null;
+
+  upsertPrintProfile(db, assetId, profile);
+  return profile;
+}
+
+function safeJsonArray(text) {
+  if (!text) return [];
+  try {
+    const parsed = JSON.parse(text);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Convert a print_profile DB row into the shape returned to the frontend. */
+export function formatPrintProfileRow(row) {
+  if (!row) return null;
+  return {
+    printer_model: row.printer_model,
+    printer_settings_name: row.printer_settings_name,
+    nozzle_diameter: row.nozzle_diameter,
+    bed_type: row.bed_type,
+    layer_height: row.layer_height,
+    first_layer_height: row.first_layer_height,
+    wall_loops: row.wall_loops,
+    infill_density: row.infill_density,
+    infill_pattern: row.infill_pattern,
+    supports_enabled: Boolean(row.supports_enabled),
+    support_type: row.support_type,
+    print_settings_name: row.print_settings_name,
+    filament_types: safeJsonArray(row.filament_types),
+    filament_colors: safeJsonArray(row.filament_colors),
+    filament_names: safeJsonArray(row.filament_names),
+    plate_count: row.plate_count,
+    makerworld_profile_id: row.makerworld_profile_id || null,
+  };
+}
+
+/**
+ * Record the MakerWorld draft/profile id a 3MF's print profile was uploaded as, so a later
+ * publish updates that same MakerWorld instance instead of creating a duplicate.
+ */
+export function setMakerWorldProfileId(db, assetId, makerworldProfileId) {
+  db.prepare(`
+    UPDATE print_profile SET makerworld_profile_id = ?, updated_at = CURRENT_TIMESTAMP
+    WHERE design_asset_id = ?
+  `).run(String(makerworldProfileId), assetId);
+}
+
+/** Bulk-fetch print profiles for a set of design_asset ids, keyed by asset id. */
+export function getPrintProfilesByAssetIds(db, assetIds) {
+  if (!assetIds || assetIds.length === 0) return {};
+  const placeholders = assetIds.map(() => '?').join(',');
+  const rows = db.prepare(`SELECT * FROM print_profile WHERE design_asset_id IN (${placeholders})`).all(...assetIds);
+  const result = {};
+  for (const row of rows) {
+    result[row.design_asset_id] = formatPrintProfileRow(row);
+  }
+  return result;
+}

--- a/src/app/lib/printProfile.js
+++ b/src/app/lib/printProfile.js
@@ -188,13 +188,19 @@ export function formatPrintProfileRow(row) {
 
 /**
  * Record the MakerWorld draft/profile id a 3MF's print profile was uploaded as, so a later
- * publish updates that same MakerWorld instance instead of creating a duplicate.
+ * publish updates that same MakerWorld instance instead of creating a duplicate. Upserts rather
+ * than plain-updates because a MakerWorld profile can be created for an asset that was synced in
+ * before local print-profile extraction existed (or whose 3mf has no recognized slicer
+ * settings), in which case there's no print_profile row yet to update.
  */
 export function setMakerWorldProfileId(db, assetId, makerworldProfileId) {
   db.prepare(`
-    UPDATE print_profile SET makerworld_profile_id = ?, updated_at = CURRENT_TIMESTAMP
-    WHERE design_asset_id = ?
-  `).run(String(makerworldProfileId), assetId);
+    INSERT INTO print_profile (design_asset_id, makerworld_profile_id, updated_at)
+    VALUES (?, ?, CURRENT_TIMESTAMP)
+    ON CONFLICT(design_asset_id) DO UPDATE SET
+      makerworld_profile_id = excluded.makerworld_profile_id,
+      updated_at = CURRENT_TIMESTAMP
+  `).run(assetId, String(makerworldProfileId));
 }
 
 /** Bulk-fetch print profiles for a set of design_asset ids, keyed by asset id. */

--- a/src/app/lib/printProfile.test.js
+++ b/src/app/lib/printProfile.test.js
@@ -1,0 +1,210 @@
+import AdmZip from 'adm-zip';
+import {
+  parseThreeMfPrintProfile,
+  generatePrintProfileForAsset,
+  formatPrintProfileRow,
+  getPrintProfilesByAssetIds,
+  setMakerWorldProfileId,
+} from './printProfile';
+
+function buildSampleThreeMf({ plateCount = 2 } = {}) {
+  const zip = new AdmZip();
+  const settings = {
+    printer_model: 'Bambu Lab X1 Carbon',
+    printer_settings_id: 'Bambu Lab X1 Carbon 0.4 nozzle',
+    nozzle_diameter: ['0.4'],
+    curr_bed_type: 'Textured PEI Plate',
+    layer_height: '0.2',
+    initial_layer_print_height: '0.2',
+    wall_loops: '3',
+    sparse_infill_density: '15%',
+    sparse_infill_pattern: 'grid',
+    enable_support: '1',
+    support_type: 'tree(auto)',
+    print_settings_id: '0.20mm Standard @BBL X1C',
+    filament_type: ['PLA', 'PETG'],
+    filament_colour: ['#FF0000', '#00FF00'],
+    filament_settings_id: ['Bambu PLA Basic @BBL X1C', 'Bambu PETG Basic @BBL X1C'],
+  };
+  zip.addFile('Metadata/project_settings.config', Buffer.from(JSON.stringify(settings)));
+  for (let i = 1; i <= plateCount; i++) {
+    zip.addFile(`Metadata/plate_${i}.json`, Buffer.from('{}'));
+  }
+  return zip.toBuffer();
+}
+
+function buildMeshOnlyThreeMf() {
+  const zip = new AdmZip();
+  zip.addFile('3D/3dmodel.model', Buffer.from('<xml/>'));
+  return zip.toBuffer();
+}
+
+function buildThreeMfWithModelSettingsPlates(plateTagCount) {
+  const zip = new AdmZip();
+  zip.addFile('Metadata/project_settings.config', Buffer.from(JSON.stringify({ printer_model: 'Bambu Lab P1S' })));
+  const plates = Array.from({ length: plateTagCount }, (_, i) => `<plate><metadata key="index" value="${i + 1}"/></plate>`).join('');
+  zip.addFile('Metadata/model_settings.config', Buffer.from(`<config>${plates}</config>`));
+  return zip.toBuffer();
+}
+
+describe('parseThreeMfPrintProfile', () => {
+  it('extracts printer/filament/plate fields from a Bambu-style project 3mf', () => {
+    const profile = parseThreeMfPrintProfile(buildSampleThreeMf({ plateCount: 3 }));
+
+    expect(profile).toEqual({
+      printer_model: 'Bambu Lab X1 Carbon',
+      printer_settings_name: 'Bambu Lab X1 Carbon 0.4 nozzle',
+      nozzle_diameter: 0.4,
+      bed_type: 'Textured PEI Plate',
+      layer_height: 0.2,
+      first_layer_height: 0.2,
+      wall_loops: 3,
+      infill_density: 15,
+      infill_pattern: 'grid',
+      supports_enabled: true,
+      support_type: 'tree(auto)',
+      print_settings_name: '0.20mm Standard @BBL X1C',
+      filament_types: ['PLA', 'PETG'],
+      filament_colors: ['#FF0000', '#00FF00'],
+      filament_names: ['Bambu PLA Basic @BBL X1C', 'Bambu PETG Basic @BBL X1C'],
+      plate_count: 3,
+    });
+  });
+
+  it('falls back to counting <plate> tags in model_settings.config when there are no plate_N.json entries', () => {
+    const profile = parseThreeMfPrintProfile(buildThreeMfWithModelSettingsPlates(4));
+    expect(profile.plate_count).toBe(4);
+  });
+
+  it('returns null for a 3mf with no slicer project settings (plain mesh export)', () => {
+    expect(parseThreeMfPrintProfile(buildMeshOnlyThreeMf())).toBeNull();
+  });
+
+  it('returns null instead of throwing for a non-zip / corrupt input', () => {
+    expect(parseThreeMfPrintProfile(Buffer.from('not a zip file'))).toBeNull();
+  });
+
+  it('returns null instead of throwing for a missing file path', () => {
+    expect(parseThreeMfPrintProfile('/nonexistent/path/model.3mf')).toBeNull();
+  });
+});
+
+function createFakeDb({ existingProfile = null } = {}) {
+  const run = jest.fn();
+  const get = jest.fn(() => existingProfile);
+  const prepare = jest.fn(() => ({ get, run, all: jest.fn(() => []) }));
+  return { prepare, _run: run, _get: get };
+}
+
+describe('generatePrintProfileForAsset', () => {
+  it('parses the file and upserts a profile for a new asset', () => {
+    const db = createFakeDb();
+    const profile = generatePrintProfileForAsset(db, 42, buildSampleThreeMf());
+
+    expect(profile).not.toBeNull();
+    expect(profile.printer_model).toBe('Bambu Lab X1 Carbon');
+    expect(db._run).toHaveBeenCalledTimes(1);
+    expect(db._run.mock.calls[0][0]).toBe(42); // design_asset_id is the first bound param
+  });
+
+  it('skips extraction when a profile already exists and force is not set', () => {
+    const db = createFakeDb({ existingProfile: { id: 1 } });
+    const profile = generatePrintProfileForAsset(db, 42, buildSampleThreeMf());
+
+    expect(profile).toBeNull();
+    expect(db._run).not.toHaveBeenCalled();
+  });
+
+  it('re-extracts and upserts when force is set, even if a profile already exists', () => {
+    const db = createFakeDb({ existingProfile: { id: 1 } });
+    const profile = generatePrintProfileForAsset(db, 42, buildSampleThreeMf(), { force: true });
+
+    expect(profile).not.toBeNull();
+    expect(db._run).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null and never upserts for a non-slicer 3mf', () => {
+    const db = createFakeDb();
+    const profile = generatePrintProfileForAsset(db, 42, buildMeshOnlyThreeMf());
+
+    expect(profile).toBeNull();
+    expect(db._run).not.toHaveBeenCalled();
+  });
+});
+
+describe('formatPrintProfileRow', () => {
+  it('returns null for a missing row', () => {
+    expect(formatPrintProfileRow(null)).toBeNull();
+  });
+
+  it('parses JSON array columns and coerces supports_enabled to a boolean', () => {
+    const row = {
+      printer_model: 'Bambu Lab X1 Carbon',
+      printer_settings_name: 'Bambu Lab X1 Carbon 0.4 nozzle',
+      nozzle_diameter: 0.4,
+      bed_type: 'Textured PEI Plate',
+      layer_height: 0.2,
+      first_layer_height: 0.2,
+      wall_loops: 3,
+      infill_density: 15,
+      infill_pattern: 'grid',
+      supports_enabled: 1,
+      support_type: 'tree(auto)',
+      print_settings_name: '0.20mm Standard @BBL X1C',
+      filament_types: '["PLA","PETG"]',
+      filament_colors: '["#FF0000","#00FF00"]',
+      filament_names: '["Bambu PLA Basic @BBL X1C"]',
+      plate_count: 2,
+    };
+
+    const formatted = formatPrintProfileRow(row);
+    expect(formatted.supports_enabled).toBe(true);
+    expect(formatted.filament_types).toEqual(['PLA', 'PETG']);
+    expect(formatted.filament_colors).toEqual(['#FF0000', '#00FF00']);
+  });
+
+  it('tolerates malformed JSON in array columns by returning an empty array', () => {
+    const row = { filament_types: 'not json', filament_colors: null, filament_names: undefined, supports_enabled: 0 };
+    const formatted = formatPrintProfileRow(row);
+    expect(formatted.filament_types).toEqual([]);
+    expect(formatted.filament_colors).toEqual([]);
+    expect(formatted.filament_names).toEqual([]);
+    expect(formatted.supports_enabled).toBe(false);
+  });
+
+  it('defaults makerworld_profile_id to null when unset, and passes it through when present', () => {
+    expect(formatPrintProfileRow({ supports_enabled: 0 }).makerworld_profile_id).toBeNull();
+    expect(formatPrintProfileRow({ supports_enabled: 0, makerworld_profile_id: '12345' }).makerworld_profile_id).toBe('12345');
+  });
+});
+
+describe('setMakerWorldProfileId', () => {
+  it('updates the row for the given asset id with a stringified profile id', () => {
+    const db = createFakeDb();
+    setMakerWorldProfileId(db, 42, 12345);
+
+    expect(db._run).toHaveBeenCalledTimes(1);
+    expect(db._run).toHaveBeenCalledWith('12345', 42);
+  });
+});
+
+describe('getPrintProfilesByAssetIds', () => {
+  it('returns an empty object without querying when given no ids', () => {
+    const db = createFakeDb();
+    expect(getPrintProfilesByAssetIds(db, [])).toEqual({});
+    expect(db.prepare).not.toHaveBeenCalled();
+  });
+
+  it('keys formatted profiles by design_asset_id', () => {
+    const rows = [
+      { design_asset_id: 1, printer_model: 'Bambu Lab X1 Carbon', filament_types: '[]', filament_colors: '[]', filament_names: '[]', supports_enabled: 1 },
+      { design_asset_id: 2, printer_model: 'Bambu Lab P1S', filament_types: '[]', filament_colors: '[]', filament_names: '[]', supports_enabled: 0 },
+    ];
+    const db = { prepare: jest.fn(() => ({ all: jest.fn(() => rows) })) };
+
+    const result = getPrintProfilesByAssetIds(db, [1, 2]);
+    expect(Object.keys(result)).toEqual(['1', '2']);
+    expect(result[1].printer_model).toBe('Bambu Lab X1 Carbon');
+    expect(result[2].printer_model).toBe('Bambu Lab P1S');
+  });
+});

--- a/src/app/lib/printProfile.test.js
+++ b/src/app/lib/printProfile.test.js
@@ -179,12 +179,40 @@ describe('formatPrintProfileRow', () => {
 });
 
 describe('setMakerWorldProfileId', () => {
-  it('updates the row for the given asset id with a stringified profile id', () => {
-    const db = createFakeDb();
+  // Uses a real in-memory database (not the mocked createFakeDb) because this needs to verify
+  // actual upsert semantics, not just which SQL string got called.
+  function createInMemoryDb() {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Database = require('better-sqlite3-local');
+    const db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE print_profile (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        design_asset_id INTEGER NOT NULL UNIQUE,
+        makerworld_profile_id TEXT,
+        updated_at TEXT
+      );
+    `);
+    return db;
+  }
+
+  it('inserts a new row when the asset has no print_profile row yet (e.g. synced before local extraction existed)', () => {
+    const db = createInMemoryDb();
+    setMakerWorldProfileId(db, 1801, 8918182);
+
+    const row = db.prepare('SELECT * FROM print_profile WHERE design_asset_id = ?').get(1801);
+    expect(row.makerworld_profile_id).toBe('8918182');
+  });
+
+  it('updates the existing row in place rather than creating a duplicate', () => {
+    const db = createInMemoryDb();
+    db.prepare('INSERT INTO print_profile (design_asset_id, makerworld_profile_id) VALUES (?, ?)').run(42, null);
+
     setMakerWorldProfileId(db, 42, 12345);
 
-    expect(db._run).toHaveBeenCalledTimes(1);
-    expect(db._run).toHaveBeenCalledWith('12345', 42);
+    const rows = db.prepare('SELECT * FROM print_profile WHERE design_asset_id = ?').all(42);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].makerworld_profile_id).toBe('12345');
   });
 });
 


### PR DESCRIPTION
## Summary

Adds print profile support in two parts:

1. **Local extraction** — parses Bambu Studio/OrcaSlicer print settings out of `.3mf` design assets (printer, nozzle, layer height, infill, supports, filament, plate count) and surfaces them on the design page. Runs automatically on upload/MakerWorld sync, with a manual re-read action for files added before this existed.
2. **MakerWorld publishing** — lets a published design's `.3mf` files be submitted as MakerWorld "Print Profiles" (their term for what the API calls an *instance*). This is a deliberate, per-file, user-confirmed action — not an automatic loop over every 3mf — because MakerWorld requires a real printed photo per profile and its own guidelines explicitly discourage splitting one model into many profiles. See [MakerWorld's Print Profile Upload Guidelines](https://wiki.bambulab.com/en/makerworld/tutorials/print-profile-upload).

The MakerWorld request shape (part 2) was verified against a real captured request from MakerWorld's own web uploader, not reverse-engineered by trial and error against the live API.

## API documentation

### New/changed PubMan routes

#### `GET /api/design/:designID` and `GET /api/design/:designID/asset`
Each entry in `assets[]` now includes a `print_profile` field:

```ts
print_profile: {
  printer_model: string | null;          // e.g. "Bambu Lab X1 Carbon"
  printer_settings_name: string | null;   // e.g. "Bambu Lab X1 Carbon 0.4 nozzle"
  nozzle_diameter: number | null;         // mm, e.g. 0.4
  bed_type: string | null;                // e.g. "Textured PEI Plate"
  layer_height: number | null;            // mm
  first_layer_height: number | null;      // mm
  wall_loops: number | null;
  infill_density: number | null;          // percent, e.g. 15
  infill_pattern: string | null;          // e.g. "gyroid"
  supports_enabled: boolean;
  support_type: string | null;            // e.g. "tree(auto)"
  print_settings_name: string | null;     // e.g. "0.20mm Standard @BBL X1C"
  filament_types: string[];               // e.g. ["PLA", "PETG"]
  filament_colors: string[];              // hex, e.g. ["#FF0000"]
  filament_names: string[];
  plate_count: number | null;
  makerworld_profile_id: string | null;   // set once a MakerWorld print profile is created for this asset
} | null
```
`null` when the asset isn't a `.3mf`, or is a `.3mf` with no recognized slicer project data (e.g. a plain mesh export), or hasn't been read yet.

#### `POST /api/design/:designID/asset/:assetID/print-profile`
(Re)generates the print profile for a `.3mf` asset by reading its slicer settings from disk. Always re-reads (force), so it doubles as both the backfill action for assets added before this feature existed and a retry after a failed extraction.

- 400 if the asset isn't a `.3mf`
- 404 if the design or asset doesn't exist
- 200 with `{ print_profile: <object> | null, message: string }` — `print_profile` is `null` if the file has no recognized slicer settings (still a 200; that's a valid outcome, not an error)

#### `GET /api/design/:designID/asset/:assetID/print-profile`
Returns the currently stored profile without re-parsing the file: `{ print_profile: <object> | null }`.

#### `PATCH /api/design/:designID/asset/:assetID/print-profile`
Records the MakerWorld draft/profile id an asset was published as, so a later publish updates that MakerWorld instance instead of creating a duplicate. Body: `{ makerworld_profile_id: string }`. Called automatically after a successful MakerWorld print profile submission — not expected to be called manually.

### `src/app/lib/printProfile.js` (server-side, not HTTP)

- `parseThreeMfPrintProfile(pathOrBuffer)` — pure parser, accepts an absolute file path or a `Buffer` (both work since it's handed straight to `adm-zip`). Returns the profile object above (minus `makerworld_profile_id`) or `null`.
- `generatePrintProfileForAsset(db, assetId, absoluteFilePath, { force })` — parses + upserts. Synchronous (uses `adm-zip`'s path-based lazy read + `better-sqlite3`), safe to call inside a `db.transaction()`. No-ops if a profile already exists unless `force: true`.
- `formatPrintProfileRow(row)` / `getPrintProfilesByAssetIds(db, assetIds)` — DB row → API shape, single or bulk.
- `setMakerWorldProfileId(db, assetId, id)` — records the MakerWorld id after a successful profile submission.

### MakerWorld "add print profile" request (`src/app/api/makerworld/makerworld-lib.js`)

Reverse-engineered from a real captured request (2026-07-21) — do not extend the field list without re-verifying against a real capture; a wrong field either silently misrepresents data on a live listing or produces a generic, undebuggable 400.

Flow (all via the existing `MakerWorldClientAPI`, session-cookie authenticated):
1. Upload the `.3mf` and the chosen photo to MakerWorld's S3 (existing `uploadAsset`/`uploadFile`).
2. `POST /v1/design-service/my/draft` (existing `createDraft`) with `AddPrintProfileRequestSchema`-shaped body — key fields:
   - `mode: "addProfile"` — the discriminator; without it the backend treats the request as a normal draft edit
   - `parentId` — the **MakerWorld design id** (not a draft id — this was the original bug)
   - `profileId: 0` for a new profile, or the previously-stored id to update one
   - `model3Mf: { name, url, size }`, `profileTitle`, `profileCover` (the required photo URL), `auxiliaryPictures: [{ name, url }]`
   - `printer: { model, variant, settingsId }` — `variant` is the nozzle diameter as a float (e.g. `0.4`), not an index
   - `compatibility: { devModelName, devProductName, nozzleDiameter }` — see `makerWorldPrinterDevModels` below
   - `projectSettings: { layerHeight, wallLoops, sparseInfillDensity }` — string-formatted, camelCase (distinct from the snake_case fields in PubMan's own `print_profile`)
   - `instanceSetting: { isPrinterPresetChanged: true, isPrinterTested: true, ... }`
3. `POST /v1/design-service/my/draft/:id/submit` (existing `publishDraft`, empty body) — creating the draft only saves it; this actually publishes it. Easy to miss since it's a separate call.

`makerWorldPrinterDevModels`: maps a parsed `printer_model` string (e.g. `"Bambu Lab P1S"`) to MakerWorld's internal `{ devModelName, devProductName }` pair (e.g. `{ devModelName: "C12", devProductName: "P1S" }`). Only contains entries confirmed from a real request — **notably missing "Bambu Lab A1 mini"** and anything non-Bambu. Unmapped printers submit with blank compatibility fields rather than a guessed code. There's a `compatibility?dev_setting_name=...` lookup endpoint visible in MakerWorld's own network traffic that likely returns this authoritatively server-side — replacing the hardcoded map with that lookup is the obvious next improvement.

### Known gaps (not attempted here)
- **`process-files`**: MakerWorld's own uploader calls this (with a polled `taskId`) after the S3 upload, before creating the draft. The one capture available was for the photo upload, not the `.3mf`, so its purpose and whether it's required weren't clear enough to replicate without guessing. If profile creation fails in a way that looks upload-related, this is the first thing to check.
- **`otherCompatibility`**: left empty (only the single detected `printer`/`compatibility` is sent). MakerWorld's own client sends a fuller list of same-nozzle-diameter printers here; under-claiming compatibility is the safer default until that logic is verified.

## Why this shape (not automatic bulk upload)

The original ask was "a print profile for each .3mf file," implemented at first as an automatic loop over every `.3mf` during publish. That corrupted a live draft's data (repeated `createDraft` calls with the wrong `parentId` all resolved to the same draft instead of creating siblings) and, once the request shape was fixed, would still have violated MakerWorld's own upload guidelines (mandatory printed photo per profile; no splitting one model into many profiles). The per-file, photo-required, manually-triggered flow in this PR is the version of that ask that's actually compatible with how MakerWorld's platform works — nothing here fires automatically during a normal publish.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx jest` — 66/66 passing, including a new regression test (`makerworld-lib.test.js`) that parses the exact real captured MakerWorld request through `AddPrintProfileRequestSchema` and asserts the key fields round-trip
- [x] `npx eslint` on all touched files — no new warnings/errors
- [x] Verified end-to-end against a real local 3MF library (printer/nozzle/layer/infill/plate-count extraction, including the plate-count fallback path for project files with no `plate_N.json`)
- [x] Verified end-to-end against the real installed app + a live MakerWorld account: local extraction UI, and a MakerWorld print profile created and confirmed live via `draft` → `submit`
